### PR TITLE
Feature digitalmediapage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,12 @@
         "react-countup": "^6.3.2",
         "react-datepicker": "^4.8.0",
         "react-dom": "^18.1.0",
+        "react-mark-image": "^0.2.3",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "recharts": "^2.1.15",
         "sass": "^1.55.0",
+        "styled-components": "^5.3.6",
         "web-vitals": "^2.1.4"
       }
     },
@@ -2075,6 +2077,29 @@
         "postcss": "^8.3",
         "postcss-selector-parser": "^6.0.10"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "node_modules/@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -5013,6 +5038,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/babel-plugin-styled-components": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
+      }
+    },
+    "node_modules/babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+    },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
@@ -5361,6 +5406,14 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-api": {
@@ -5839,6 +5892,14 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
@@ -6019,6 +6080,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
@@ -14141,6 +14212,18 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "node_modules/react-mark-image": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/react-mark-image/-/react-mark-image-0.2.3.tgz",
+      "integrity": "sha512-BcM+1FV51gZJtrxfSpC0QkC5mn883UYmZULVPApmdkBuiCcfcurqzVzYhq6oEVKz4GWTxVrl+P+uzYQko0J/hw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "styled-components": ">=5.3.3"
+      }
+    },
     "node_modules/react-onclickoutside": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz",
@@ -15094,6 +15177,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15507,6 +15595,36 @@
       "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
       "dependencies": {
         "inline-style-parser": "0.1.1"
+      }
+    },
+    "node_modules/styled-components": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
+      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
       }
     },
     "node_modules/stylehacks": {
@@ -18510,6 +18628,29 @@
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-1.0.0.tgz",
       "integrity": "sha512-RkYG5KiGNX0fJ5YoI0f4Wfq2Yo74D25Hru4fxTOioYdQvHBxcrrtTTyT5Ozzh2ejcNrhFy7IEts2WyEY7yi5yw=="
     },
+    "@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
     "@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -20664,6 +20805,23 @@
         "@babel/helper-define-polyfill-provider": "^0.3.1"
       }
     },
+    "babel-plugin-styled-components": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+    },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
@@ -20923,6 +21081,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
+    },
+    "camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -21289,6 +21452,11 @@
         "postcss-selector-parser": "^6.0.9"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+    },
     "css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
@@ -21393,6 +21561,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
@@ -27145,6 +27323,11 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-mark-image": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/react-mark-image/-/react-mark-image-0.2.3.tgz",
+      "integrity": "sha512-BcM+1FV51gZJtrxfSpC0QkC5mn883UYmZULVPApmdkBuiCcfcurqzVzYhq6oEVKz4GWTxVrl+P+uzYQko0J/hw=="
+    },
     "react-onclickoutside": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz",
@@ -27849,6 +28032,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -28163,6 +28351,23 @@
       "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
       "requires": {
         "inline-style-parser": "0.1.1"
+      }
+    },
+    "styled-components": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
+      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
       }
     },
     "stylehacks": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "react-countup": "^6.3.2",
     "react-datepicker": "^4.8.0",
     "react-dom": "^18.1.0",
+    "react-mark-image": "^0.2.3",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "recharts": "^2.1.15",
     "sass": "^1.55.0",
+    "styled-components": "^5.3.6",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,8 @@ import Annotate from "templates/annotate/Annotate";
 
 import Profile from "templates/profile/Profile";
 
+import DigitalMedia from "templates/digitalMedia/DigitalMedia";
+
 
 const App = () => {
     return (
@@ -31,6 +33,8 @@ const App = () => {
                     <Route path="/annotate" element={<Annotate />} />
 
                     <Route path="/profile" element={<Profile />} />
+
+                    <Route path="/dm/:prefix/:suffix" element={<DigitalMedia />} />
                 </Routes>
             </Router>
         </>

--- a/src/api/digitalMedia/FilterDigitalMedia.js
+++ b/src/api/digitalMedia/FilterDigitalMedia.js
@@ -1,0 +1,42 @@
+import DigitalMediaFilterLayer from 'sources/digitalMediaFilterLayer';
+
+
+function FilterDigitalMedia(digitalMediaItem) {
+    let digitalMediaItemProperties = {
+        Other: {}
+    };
+
+    for (let property in DigitalMediaFilterLayer) {
+        let propertyInfo;
+
+        if (property in digitalMediaItem) {
+            propertyInfo = { ...DigitalMediaFilterLayer[property], ...{ value: digitalMediaItem[property],  } };
+        } else if (`dwc:${property}` in digitalMediaItem['data']) {
+            propertyInfo = { ...DigitalMediaFilterLayer[property], ...{ value: digitalMediaItem['data'][`dwc:${property}`] } };
+        } else if (`dcterms:${property}` in digitalMediaItem['data']) {
+            propertyInfo = { ...DigitalMediaFilterLayer[property], ...{ value: digitalMediaItem['data'][`dcterms:${property}`] } };
+        } else {
+            let defaultValue = "Undefined";
+
+            if ('default' in DigitalMediaFilterLayer[property]) {
+                defaultValue = DigitalMediaFilterLayer[property]['default'];
+            }
+
+            propertyInfo = { ...DigitalMediaFilterLayer[property], ...{ value: defaultValue } };
+        }
+
+        digitalMediaItemProperties[propertyInfo['group']] = { ...digitalMediaItemProperties[propertyInfo['group']], [property]: propertyInfo };
+    }
+
+    if (Object.keys(digitalMediaItemProperties['Other']).length === 0) {
+        delete digitalMediaItemProperties['Other'];
+    } else {
+        const other = digitalMediaItemProperties['other'];
+        delete digitalMediaItemProperties['Other'];
+        digitalMediaItemProperties['other'] = other;
+    }
+
+    return digitalMediaItemProperties;
+}
+
+export default FilterDigitalMedia;

--- a/src/api/digitalMedia/getDigitalMedia.js
+++ b/src/api/digitalMedia/getDigitalMedia.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+
+function GetDigitalMedia(handle, callback) {
+    const endPoint = `digitalmedia/${handle}`;
+
+    axios({
+        method: "get",
+        url: endPoint,
+        responseType: 'json'
+    }).then(function (result) {
+        callback(result['data']);
+    }).catch(error => {
+        /* To be replaced by logger */
+        console.warn(error);
+    });
+}
+
+export default GetDigitalMedia;

--- a/src/api/specimen/GetSpecimenDigitalMedia.js
+++ b/src/api/specimen/GetSpecimenDigitalMedia.js
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
 
-function GetSpecimenDigitalMedia(specimen, callback) {
-    const handle = specimen['Meta']['id']['value'];
-
+function GetSpecimenDigitalMedia(handle, callback) {
     if (handle) {
         const endPoint = `specimens/${handle}/digitalmedia`;
 
@@ -12,7 +10,7 @@ function GetSpecimenDigitalMedia(specimen, callback) {
             url: endPoint,
             responseType: 'json'
         }).then(function (result) {
-            callback(result['data'], specimen);
+            callback(result['data']);
         }).catch(error => {
             /* To be replaced by logger */
             console.warn(error);

--- a/src/sources/digitalMediaFilterLayer.json
+++ b/src/sources/digitalMediaFilterLayer.json
@@ -1,0 +1,86 @@
+{
+    "id": {
+        "displayName": "Handle identifier",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "format": {
+        "displayName": "Format",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "digitalSpecimenId": {
+        "displayName": "Digital specimen identifier",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "mediaUrl": {
+        "displayName": "Media URL",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "sourceSystemId": {
+        "displayName": "Source system identifier",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "type": {
+        "displayName": "Media type",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "version": {
+        "displayName": "Version",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "creator": {
+        "displayName": "Creator",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "description": {
+        "displayName": "Description",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "license": {
+        "displayName": "License",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "publisher": {
+        "displayName": "Publisher",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "references": {
+        "displayName": "References",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "rightsHolder": {
+        "displayName": "Rights holder",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    },
+    "title": {
+        "displayName": "Title",
+        "group": "MediaMeta",
+        "annotatable": true,
+        "mids": ""
+    }
+}

--- a/src/templates/digitalMedia/DigitalMedia.js
+++ b/src/templates/digitalMedia/DigitalMedia.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import './digitalMedia.scss';
+
+/* Import Components */
+import Header from 'templates/header/Header';
+import Body from './body/Body';
+import Footer from 'templates/footer/Footer';
+
+/* Import API */
+import GetDigitalMedia from 'api/digitalMedia/getDigitalMedia';
+import FilterDigitalMedia from 'api/digitalMedia/FilterDigitalMedia';
+
+
+const DigitalMedia = () => {
+    const params = useParams();
+
+    const [digitalMediaItem, setDigitalMediaItem] = useState();
+
+    useEffect(() => {
+        const handle = `${params['prefix']}/${params['suffix']}`;
+
+        GetDigitalMedia(handle, Process);
+
+        function Process(result) {
+            const filteredDigitalMediaItem = FilterDigitalMedia(result);
+            
+            setDigitalMediaItem(filteredDigitalMediaItem);
+        }
+    }, [params]);
+
+    if (digitalMediaItem) {
+        return (
+            <div className="h-100">
+                <Header />
+
+                <Body digitalMediaItem={digitalMediaItem} />
+
+                <Footer page={'notHome'} />
+            </div>
+        );
+    }
+}
+
+export default DigitalMedia;

--- a/src/templates/digitalMedia/body/Body.js
+++ b/src/templates/digitalMedia/body/Body.js
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+import { Container, Row, Col } from 'react-bootstrap';
+import UserService from 'keycloak/Keycloak';
+
+/* Import Components */
+import MediaList from './mediaList/MediaList';
+import MediaFrame from './mediaFrame/MediaFrame';
+import MediaData from './mediaData/MediaData';
+import MediaAnnotaions from './mediaAnnotations/MediaAnnotations';
+
+import MediaModal from './mediaModal/MediaModal';
+import AnnotateModal from 'templates/specimen/body/annotate/AnnotateModal';
+
+/* Import API */
+import GetAnnotations from 'api/annotate/GetAnnotations';
+
+
+const Body = (props) => {
+    const digitalMediaItem = props.digitalMediaItem;
+
+    const [chosenDigitalMediaTab, setChosenDigitalMediaTab] = useState({ meta: 'active' });
+    const [mediaModalToggle, setMediaModalToggle] = useState(false);
+
+    function ToggleMediaModal() {
+        setMediaModalToggle(!mediaModalToggle);
+    }
+
+    const [modalToggle, setModalToggle] = useState(false);
+    const [modalProperty, setModalProperty] = useState({ 'property': '' });
+    const [annotationType, setAnnotationType] = useState({});
+    const [modalAnnotations, setModalAnnotations] = useState();
+
+    function SetAnnotationType(type, form = false) {
+        const copyAnnotationType = { ...annotationType }
+
+        copyAnnotationType['type'] = type;
+        copyAnnotationType['form'] = form;
+
+        setAnnotationType(copyAnnotationType);
+    }
+
+    useEffect(() => {
+        SetAnnotations();
+    }, [digitalMediaItem]);
+
+    function SetAnnotations() {
+        /* Search for annotations data and put into view */
+        GetAnnotations(digitalMediaItem['MediaMeta']['id']['value'], Process);
+
+        function Process(annotations) {
+            const annotationsForModal = {};
+
+            for (const i in annotations) {
+                const annotation = annotations[i];
+
+                if (!annotationsForModal[annotation['target']['indvProp']]) {
+                    annotationsForModal[annotation['target']['indvProp']] = { [annotation['motivation']]: { [annotation['creator']]: annotation } };
+                } else if (!annotationsForModal[annotation['target']['indvProp']][annotation['motivation']]) {
+                    annotationsForModal[annotation['target']['indvProp']][annotation['motivation']] = { [annotation['creator']]: annotation };
+                } else {
+                    annotationsForModal[annotation['target']['indvProp']][annotation['motivation']][annotation['creator']] = annotation;
+                }
+            }
+
+            setModalAnnotations(annotationsForModal);
+        }
+    }
+
+    function ToggleModal(propertyObject, property = null, type = null) {
+        if (UserService.isLoggedIn()) {
+            setModalToggle(!modalToggle);
+
+            if (!modalToggle) {
+                if (type) {
+                    SetAnnotationType(type);
+                }
+            }
+
+            if (property && property !== modalProperty['property']) {
+                let copyModalProperty = { ...modalProperty };
+
+                copyModalProperty['property'] = property;
+                copyModalProperty['displayName'] = propertyObject['displayName'];
+                copyModalProperty['currentValue'] = propertyObject['value'];
+
+                setModalProperty(copyModalProperty);
+            }
+        }
+    }
+
+    return (
+        <Container fluid className="digitalMedia_body mt-4 ">
+            <Row className="digitalMedia_mediaBody">
+                <Col md={{ span: 10, offset: 1 }} className="h-100">
+                    <Row className="h-100">
+                        <Col md={{ span: 9 }} className="h-100">
+                            <Row className="digitalMedia_titleBlock fw-bold pe-1">
+                                <Col className="bg-primary-blue text-white">
+                                    {digitalMediaItem['MediaMeta']['digitalSpecimenId']['value']}
+                                </Col>
+                            </Row>
+                            <Row className="digitalMedia_mediaBodyImages">
+                                <Col md={{ span: 3 }}>
+                                    <MediaList digitalMediaItem={digitalMediaItem} />
+                                </Col>
+
+                                <Col md={{ span: 9 }} className="h-100">
+                                    <MediaFrame digitalMediaItem={digitalMediaItem} />
+                                </Col>
+                            </Row>
+                        </Col>
+
+                        <Col md={{ span: 3 }} className="h-100 overflow-hidden">
+                            <Row>
+                                <Col className={`digitalMedia_mediaBodyTab ${chosenDigitalMediaTab['meta']} col-md-auto border border-bottom-0 border-dark`}
+                                    onClick={() => setChosenDigitalMediaTab({ 'meta': 'active' })}
+                                >
+                                    Metadata
+                                </Col>
+                                <Col className={`digitalMedia_mediaBodyTab ${chosenDigitalMediaTab['annotate']} col-md-auto border border-bottom-0 border-dark`}
+                                    onClick={() => setChosenDigitalMediaTab({ 'annotate': 'active' })}
+                                >
+                                    Annotations
+                                </Col>
+                            </Row>
+                            <Row className="digitalMedia_mediaMetaContent overflow-scroll w-100 border border-dark">
+                                <Col className={`digitalMedia_mediaBodyContent ${chosenDigitalMediaTab['meta']}`}>
+                                    <MediaData digitalMediaItem={digitalMediaItem}
+                                        ToggleMediaModal={() => ToggleMediaModal()}
+                                        ToggleModal={(propertyObject, property) => ToggleModal(propertyObject, property)}
+                                    />
+                                </Col>
+                                <Col className={`digitalMedia_mediaBodyContent ${chosenDigitalMediaTab['annotate']}`}>
+                                    <MediaAnnotaions annotations={modalAnnotations} 
+                                        ToggleModal={(propertyObject, property, motivation) => ToggleModal(propertyObject, property, motivation)}
+                                    />
+                                </Col>
+                            </Row>
+                        </Col>
+                    </Row>
+                </Col>
+            </Row>
+
+            <MediaModal
+                digitalMediaItem={digitalMediaItem}
+                mediaModalToggle={mediaModalToggle}
+
+                ToggleMediaModal={() => ToggleMediaModal()}
+            />
+
+            <AnnotateModal
+                targetId={digitalMediaItem['MediaMeta']['id']['value']}
+                targetType={'digital_media'}
+
+                modalToggle={modalToggle}
+                modalProperty={modalProperty}
+                modalAnnotations={modalAnnotations}
+                annotationType={annotationType}
+
+                ToggleModal={(propertyObject, property) => ToggleModal(propertyObject, property)}
+                SetAnnotationType={(type, form) => SetAnnotationType(type, form)}
+                SetModalAnnotations={(modalAnnotations) => setModalAnnotations(modalAnnotations)}
+            />
+        </Container>
+    );
+}
+
+export default Body;

--- a/src/templates/digitalMedia/body/mediaAnnotations/MediaAnnotations.js
+++ b/src/templates/digitalMedia/body/mediaAnnotations/MediaAnnotations.js
@@ -1,0 +1,80 @@
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Sources */
+import DigitalMediaFilterLayer from 'sources/digitalMediaFilterLayer';
+
+
+const MediaAnnotaions = (props) => {
+    const annotations = props.annotations;
+
+    if (annotations) {
+        if (Object.keys(annotations).length > 0) {
+            return (
+                <Row className="h-100">
+                    <Col>
+                        <Row>
+                            <Col className="digitalMedia_annotationsBlockHeader px-4 py-2 fw-bold">
+                                <Row>
+                                    <Col md={{ span: 7 }}>
+                                        Attribute
+                                    </Col>
+                                    <Col md={{ span: 5 }}>
+                                        Type
+                                    </Col>
+                                </Row>
+                            </Col>
+                        </Row>
+
+                        <Row>
+                            <Col className="digitalMedia_annotationsBlock">
+                                {Object.keys(annotations).map((group, _i) => {
+                                    const annotationGroup = annotations[group];
+
+                                    let annotationView = [];
+
+                                    for (const key in annotationGroup) {
+                                        const annotationObjects = annotationGroup[key];
+
+                                        for (const secondKey in annotationGroup[key]) {
+                                            const annotationObject = annotationObjects[secondKey];
+                                            const propertyObject = DigitalMediaFilterLayer[annotationObject['target']['indvProp']];
+
+                                            annotationView.push(
+                                                <Row>
+                                                    <Col className="digitalMedia_annotationsBlockRow px-4 py-2 border-b-1-primary-dark"
+                                                        onClick={() => props.ToggleModal(propertyObject, annotationObject['target']['indvProp'], annotationObject['motivation'])}
+                                                    >
+                                                        <Row key={secondKey}>
+                                                            <Col md={{ span: 7 }}>
+                                                                {`${annotationObject['target']['indvProp']} `}
+                                                            </Col>
+                                                            <Col md={{ span: 5 }}>
+                                                                {`${annotationObject['motivation']}`}
+                                                            </Col>
+                                                        </Row>
+                                                    </Col>
+                                                </Row>
+                                            );
+                                        }
+                                    }
+
+                                    return annotationView;
+                                })}
+                            </Col>
+                        </Row>
+                    </Col>
+                </Row>
+            );
+        } else {
+            return (
+                <Row>
+                    <Col className="digitalMedia_annotationsBlock px-4 py-2">
+                        No annotations yet
+                    </Col>
+                </Row>
+            );
+        }
+    }
+}
+
+export default MediaAnnotaions;

--- a/src/templates/digitalMedia/body/mediaData/MediaData.js
+++ b/src/templates/digitalMedia/body/mediaData/MediaData.js
@@ -1,0 +1,40 @@
+import { Row, Col } from 'react-bootstrap';
+
+
+const MediaData = (props) => {
+    const digitalMediaItem = props.digitalMediaItem;
+
+    return (
+        <Row className="overflow-scroll">
+            <Col className="px-4 py-2 mt-2">
+                {Object.keys(digitalMediaItem['MediaMeta']).map((key, i) => {
+                    const metaItem = digitalMediaItem['MediaMeta'][key];
+
+                    return (
+                        <Row key={i}>
+                            <Col>
+                                <Row>
+                                    <Col md={{span: 12}} className="digitalMedia_attributeBlock border-l-1-primary-dark mb-2 text-truncate py-1"
+                                        onClick={() => props.ToggleModal(metaItem, key)}
+                                    >
+                                        <span className="fst-italic"> {`${metaItem['displayName']}: `} </span> {`${metaItem['value']}`}
+                                    </Col>
+                                </Row>
+                            </Col>
+                        </Row>
+                    );
+                })}
+
+                <Row>
+                    <Col>
+                        <button onClick={() => props.ToggleMediaModal()} >
+                            Annotate
+                        </button>
+                    </Col>
+                </Row>
+            </Col>
+        </Row>
+    );
+}
+
+export default MediaData;

--- a/src/templates/digitalMedia/body/mediaFrame/MediaFrame.js
+++ b/src/templates/digitalMedia/body/mediaFrame/MediaFrame.js
@@ -1,0 +1,28 @@
+import { Row, Col } from 'react-bootstrap';
+
+
+const MediaFrame = (props) => {
+    const digitalMediaItem = props.digitalMediaItem;
+
+    let digitalMediaContent;
+
+    switch (digitalMediaItem['MediaMeta']['type']['value']) {
+        case "2DImageObject":
+            digitalMediaContent = <img src={digitalMediaItem['MediaMeta']['mediaUrl']['value']}
+                alt={digitalMediaItem['MediaMeta']['id']['value']}
+                className="w-100 h-100 border border-white"
+            />
+
+            break;
+    }
+
+    return (
+        <Row className="h-100">
+            <Col className="d-flex align-items-center px-1 h-100">
+                {digitalMediaContent}
+            </Col>
+        </Row>
+    );
+}
+
+export default MediaFrame;

--- a/src/templates/digitalMedia/body/mediaList/MediaList.js
+++ b/src/templates/digitalMedia/body/mediaList/MediaList.js
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Components */
+import MediaListItem from './MediaListItem';
+
+/* Import API */
+import GetSpecimenDigitalMedia from 'api/specimen/GetSpecimenDigitalMedia';
+
+
+const MediaList = (props) => {
+    const digitalMediaItem = props.digitalMediaItem;
+
+    const [specimenDigitalMediaItems, setSpecimenDigitalMediaItems] = useState();
+
+    useEffect(() => {
+        GetSpecimenDigitalMedia(digitalMediaItem['MediaMeta']['digitalSpecimenId']['value'], Process);
+
+        function Process(result) {
+            setSpecimenDigitalMediaItems(result);
+        }
+    }, []);
+
+    if (specimenDigitalMediaItems) {
+        let digitalMediaItemsView = [];
+
+        for (const i in specimenDigitalMediaItems) {
+            if (digitalMediaItem['MediaMeta']['id']['value'] === specimenDigitalMediaItems[i]['id']) {
+                digitalMediaItemsView.push(
+                    <Row key={i}>
+                        <Col className="border border-white position-relative">
+                            <MediaListItem digitalMediaItem={specimenDigitalMediaItems[i]} 
+                                chosen={'chosen'}
+                            />
+
+                            <div className="position-absolute bg-dark w-100 h-100 start-0 top-0 opacity-50" />
+                        </Col>
+                    </Row>
+                );
+            } else {
+                digitalMediaItemsView.push(
+                    <Row key={i}>
+                        <Col className="border border-white">
+                            <MediaListItem digitalMediaItem={specimenDigitalMediaItems[i]} />
+                        </Col>
+                    </Row>
+                );
+            }
+        }
+
+        return digitalMediaItemsView;
+    }
+}
+
+export default MediaList;

--- a/src/templates/digitalMedia/body/mediaList/MediaListItem.js
+++ b/src/templates/digitalMedia/body/mediaList/MediaListItem.js
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Row, Col } from 'react-bootstrap';
+
+
+const MediaListItem = (props) => {
+    const digitalMediaItem = props.digitalMediaItem;
+    const chosen = props.chosen;
+
+    let digitalMediaContent;
+
+    switch (digitalMediaItem['type']) {
+        case "2DImageObject":
+            digitalMediaContent = <img src={digitalMediaItem['mediaUrl']}
+                alt={digitalMediaItem['id']}
+                className="w-100"
+            />
+
+            break;
+    }
+
+    const [hoverOn, setHoverOn] = useState();
+
+    useEffect(() => {
+        setHoverOn();
+    }, [chosen])
+
+    function HoverOnMediaListItem(hover) {
+        if (hover) {
+            setHoverOn('hover');
+        } else {
+            setHoverOn();
+        }
+    }
+
+    return (
+        <Row>
+            {(chosen) ?
+                <Col className={`digitalMedia_mediaListItem ${chosen} position-relative d-flex align-items-center justify-content-center`}>
+                    <div className={`digitalMedia_mediaListItemImage position-absolute overflow-hidden w-100 h-100 top-0 start-0`}>
+                        {digitalMediaContent}
+                    </div>
+
+                    <div className={`digitalMedia_mediaListItemText ${chosen} position-relative text-center z-1 fw-bold`}>
+                        {digitalMediaItem['type']}
+                    </div>
+                </Col>
+                : <Link to={`/dm/${digitalMediaItem['id']}`}>
+                    <Col className={`digitalMedia_mediaListItem ${hoverOn} position-relative d-flex align-items-center justify-content-center`}
+                        onMouseEnter={() => HoverOnMediaListItem(true)}
+                        onMouseLeave={() => HoverOnMediaListItem(false)}
+                    >
+                        <div className={`digitalMedia_mediaListItemImage ${hoverOn} position-absolute overflow-hidden w-100 h-100 top-0 start-0`}>
+                            {digitalMediaContent}
+                        </div>
+
+                        <div className={`digitalMedia_mediaListItemText ${hoverOn} position-relative text-center z-1 fw-bold`}>
+                            {digitalMediaItem['type']}
+                        </div>
+                    </Col>
+                </Link>
+            }
+        </Row>
+    );
+}
+
+export default MediaListItem;

--- a/src/templates/digitalMedia/body/mediaModal/ImageAnnotate.js
+++ b/src/templates/digitalMedia/body/mediaModal/ImageAnnotate.js
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Annotation } from 'react-mark-image';
 
 

--- a/src/templates/digitalMedia/body/mediaModal/ImageAnnotate.js
+++ b/src/templates/digitalMedia/body/mediaModal/ImageAnnotate.js
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { Annotation } from 'react-mark-image';
+
+
+const ImageAnnotate = (props) => {
+    const digitalMediaItem = props.digitalMediaItem;
+    const annotations = props.annotations;
+
+    return (
+        <Annotation
+            src={digitalMediaItem['MediaMeta']['mediaUrl']['value']}
+            alt={digitalMediaItem['id']}
+            onAnnotationsUpdate={(annotations) => props.SetAnnotations(annotations)}
+            annotations={annotations}
+            className="h-100"
+        />
+    );
+}
+
+export default ImageAnnotate;

--- a/src/templates/digitalMedia/body/mediaModal/MediaModal.js
+++ b/src/templates/digitalMedia/body/mediaModal/MediaModal.js
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { Row, Col, Modal } from 'react-bootstrap';
+
+/* Import Components */
+import ImageAnnotate from './ImageAnnotate';
+
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faX } from '@fortawesome/free-solid-svg-icons';
+
+
+const MediaModal = (props) => {
+    const digitalMediaItem = props.digitalMediaItem;
+    const mediaModalToggle = props.mediaModalToggle;
+
+    const [annotations, setAnnotations] = useState([]);
+
+    return (
+        <Modal show={mediaModalToggle} size="xl" className="digitalMedia_modal">
+            <Row className="h-100 justify-content-center">
+                <Col className="h-100">
+                    <Row className="h-100">
+                        <Col md={{ span: 10 }} className="bg-white pe-0 h-100 position-relative">
+                            <ImageAnnotate digitalMediaItem={digitalMediaItem}
+                                annotations={annotations}
+
+                                SetAnnotations={(annotations) => setAnnotations(annotations)}
+                            />
+
+                            <Col className="position-absolute end-0 top-0 me-3 mt-2">
+                                <FontAwesomeIcon icon={faX}
+                                    className="digitalMedia_modalCloseButton"
+                                    onClick={() => props.ToggleMediaModal()}
+                                />
+                            </Col>
+                        </Col>
+                        <Col md={{ span: 2 }} className="digitalMedia_modalMenu bg-backdrop h-100 end-0">
+                            <Row>
+                                <Col className="digitalMedia_modalMenuTitle text-white fw-bold ps-4 bg-primary-blue">
+                                    Image Annotation
+                                </Col>
+                            </Row>
+                            <Row>
+                                <Col>
+                                   
+                                </Col>
+                            </Row>
+                        </Col>
+                    </Row>
+                </Col>
+            </Row>
+        </Modal>
+    );
+}
+
+export default MediaModal;

--- a/src/templates/digitalMedia/digitalMedia.scss
+++ b/src/templates/digitalMedia/digitalMedia.scss
@@ -1,0 +1,147 @@
+/* Custom styling for digital specimen page */
+
+.digitalMedia_body {
+    height: Calc(100% - 147px);
+}
+
+.digitalMedia_mediaBody {
+    height: 70%;
+}
+
+.digitalMedia_titleBlock {
+    height: 40px;
+    line-height: 40px;
+    font-size: 20px;
+}
+
+.digitalMedia_mediaBodyImages {
+    height: Calc(100% - 40px) !important;
+}
+
+.digitalMedia_mediaBodyTab {
+    height: 40px;
+    line-height: 40px;
+    background-color: var(--greyXLight);
+    cursor: pointer;
+}
+
+.digitalMedia_mediaBodyTab.active {
+    background-color: var(--main-color-dark);
+    color: white;
+    cursor: default;
+}
+
+.digitalMedia_mediaBodyContent {
+    display: none;
+}
+
+.digitalMedia_mediaBodyContent.active {
+    display: block;
+}
+
+.digitalMedia_mediaMetaContent {
+    height: Calc(100% - 40px);
+}
+
+
+/* Media List */
+
+.digitalMedia_mediaListItem {
+    height: 80px;
+}
+
+.digitalMedia_mediaListItem.hover {
+    cursor: pointer;
+}
+
+.digitalMedia_mediaListItemImage.hover {
+    background-color: white;
+    opacity: 0.8;
+}
+
+.digitalMedia_mediaListItemText {
+    display: none;
+}
+
+.digitalMedia_mediaListItemText.hover {
+    display: initial;
+}
+
+.digitalMedia_mediaListItemText.chosen {
+    display: initial;
+    color: white;
+}
+
+
+/* Media Attributes */
+
+.digitalMedia_attributeBlock {
+    font-size: 14px;
+    transition: 0.4s;
+    cursor: pointer;
+}
+
+.digitalMedia_attributeBlock:hover {
+    background-color: var(--greyLight);
+}
+
+
+/* Media Annotations */
+
+.digitalMedia_annotationsBlock {
+    font-size: 14px;
+}
+
+.digitalMedia_annotationsBlockHeader {
+    background-color: var(--greyLight);
+    font-size: 14px;
+}
+
+.digitalMedia_annotationsBlockRow {
+    transition: 0.4s;
+    cursor: pointer;
+}
+
+.digitalMedia_annotationsBlockRow:hover {
+    background-color: var(--main-color-light);
+}
+
+
+/* Media Modal */
+
+.digitalMedia_modal .modal-dialog {
+    height: 100%;
+    margin: 0 auto !important;
+}
+
+.digitalMedia_modal .modal-content {
+    background-color: rgba(255, 255, 255, 0);
+    height: 84.8%;
+    overflow: hidden;
+    padding-top: 11.2%;
+    border: none;
+}
+
+
+/* Media Modal Menu */
+
+.digitalMedia_modalMenuTitle {
+    height: 41px;
+    line-height: 41px;
+}
+
+.digitalMedia_modalCloseButton {
+    cursor: pointer;
+}
+
+
+/* Media Modal Image Annotate */
+
+.hAjSKD {
+    height: Calc(100% - 41px);
+}
+
+.dCXmIN {
+    height: 100%;
+}
+

--- a/src/templates/header/header.scss
+++ b/src/templates/header/header.scss
@@ -53,7 +53,7 @@
 }
 
 .header_loginButton:hover {
-    background-color: var(--main-color-darker);
+    background-color: var(--main-color-dark);
     color: white;
 }
 

--- a/src/templates/home/body/recentAnnotations/RecentAnnotations.js
+++ b/src/templates/home/body/recentAnnotations/RecentAnnotations.js
@@ -26,6 +26,8 @@ const RecentAnnotations = () => {
     const [backgroundHover, setBackgroundHover] = useState({});
 
     if (recentAnnotations) {
+        console.log(recentAnnotations);
+
         return (
             <Row className="mt-5 position-relative">
                 <Col>
@@ -45,8 +47,18 @@ const RecentAnnotations = () => {
                                     <Col md={{ span: 12 }}>
                                         <Row>
                                             {recentAnnotations.map((annotation, i) => {
-                                                if (!annotation['specimen']['specimenName']) {
-                                                    annotation['specimen']['specimenName'] = 'Undefined name';
+                                                /* Temporary solution */
+                                                if (annotation['target']['type'] === 'digital_specimen') {
+                                                    if (!annotation['specimen']['specimenName']) {
+                                                        annotation['targetName'] = 'Undefined name';
+                                                    } else {
+                                                        annotation['targetName'] = annotation['specimen']['specimenName'];
+                                                    }
+
+                                                    annotation['targetPage'] = 'ds';
+                                                } else if (annotation['target']['type'] === 'digital_media') {
+                                                    annotation['targetName'] = annotation['target']['id'];
+                                                    annotation['targetPage'] = 'dm';
                                                 }
 
                                                 return (
@@ -57,12 +69,12 @@ const RecentAnnotations = () => {
                                                                 onMouseEnter={() => setBackgroundHover({ [i]: 'active' })}
                                                                 onMouseLeave={() => setBackgroundHover({})}
                                                             >
-                                                                <Link to={`/ds/${annotation['specimen']['id']}`}>
+                                                                <Link to={`/${annotation['targetPage']}/${annotation['target']['id'].replace('https://hdl.handle.net/', '')}`}>
                                                                     <Row className="py-2 position-relative z-1">
                                                                         <Col md={{ span: 10 }}>
                                                                             <Row>
                                                                                 <Col md={{ span: 12 }} className="recentAnnotationTitle fw-bold">
-                                                                                    {annotation['specimen']['specimenName']}
+                                                                                    {annotation['targetName']}
                                                                                 </Col>
                                                                                 <Col md={{ span: 12 }}>
                                                                                     {`${annotation['target']['indvProp']}`} was annoted by: Username
@@ -74,8 +86,8 @@ const RecentAnnotations = () => {
                                                                         </Col>
                                                                     </Row>
 
-                                                                    <FontAwesomeIcon icon={faBug} 
-                                                                        className={`recentAnnotationIcon position-absolute z-0 ${backgroundHover[i]}`} 
+                                                                    <FontAwesomeIcon icon={faBug}
+                                                                        className={`recentAnnotationIcon position-absolute z-0 ${backgroundHover[i]}`}
                                                                     />
                                                                     <div className={`recentAnnotationBackground ${backgroundHover[i]}`} />
                                                                     <div md={{ span: 2 }} className={`position-absolute recentAnnotationGo ${backgroundHover[i]}`} />

--- a/src/templates/specimen/Specimen.js
+++ b/src/templates/specimen/Specimen.js
@@ -32,16 +32,16 @@ const Specimen = () => {
 
         setSpecimen(filteredSpecimen);
 
-        GetSpecimenDigitalMedia(filteredSpecimen, ProcessMedia);
-    }
+        GetSpecimenDigitalMedia(filteredSpecimen['Meta']['id']['value'], ProcessMedia);
 
-    function ProcessMedia(media, specimenObject) {
-        if (media) {
-            const completeSpecimen = { ...specimenObject };
+        function ProcessMedia(media) {
+            if (media) {
+                const completeSpecimen = { ...filteredSpecimen };
 
-            completeSpecimen['media'] = media;
+                completeSpecimen['media'] = media;
 
-            setSpecimen(completeSpecimen);
+                setSpecimen(completeSpecimen);
+            }
         }
     }
 

--- a/src/templates/specimen/body/annotate/AnnotateModal.js
+++ b/src/templates/specimen/body/annotate/AnnotateModal.js
@@ -19,13 +19,36 @@ import QualityFlaggingMessage from './annotationTypes/qualityFlagging/QualityFla
 import AddingForm from './annotationTypes/adding/AddingForm';
 import AddingMessage from './annotationTypes/adding/AddingMessage';
 
+/* Import API */
+import InsertAnnotation from 'api/annotate/InsertAnnotation';
+import DeleteAnnotation from 'api/annotate/DeleteAnnotation';
+
 
 const AnnotateModal = (props) => {
+    const targetId = props.targetId;
+    const targetType = props.targetType;
+
     const modalToggle = props.modalToggle;
     const modalAnnotations = props.modalAnnotations;
     const modalProperty = props.modalProperty;
     const annotationType = props.annotationType;
-    const annotationTypes = props.annotationTypes;
+
+    const annotationTypes = [{
+        key: "commenting",
+        displayName: "Commenting"
+    }, {
+        key: "linking",
+        displayName: "Relationship/Link"
+    }, {
+        key: "correcting",
+        displayName: "Error correction"
+    }, {
+        key: "quality_flagging",
+        displayName: "Quality flag"
+    }, {
+        key: "adding",
+        displayName: "Addition"
+    }];
 
     const [formData, setFormData] = useState({
         attribute: modalProperty['property'],
@@ -51,6 +74,7 @@ const AnnotateModal = (props) => {
     useEffect(() => {
         if (propertyAnnotations && modalToggle) {
             const userId = UserService.getSubject();
+
             let localValues = {
                 commenting: {},
                 adding: {},
@@ -151,6 +175,10 @@ const AnnotateModal = (props) => {
     function ToggleAnnotationForm(close = false) {
         if (annotationFormToggle || close) {
             setAnnotationFormToggle('');
+
+            if (editType) {
+                setEditType();
+            }
         } else {
             setAnnotationFormToggle('active');
 
@@ -208,15 +236,55 @@ const AnnotateModal = (props) => {
                 ...formData['annotationTypes'][annotationType]
             },
             target: {
-                type: 'digital_specimen',
+                type: targetType,
                 indvProp: modalProperty['property']
             }
         };
 
-        props.SaveAnnotation(annotation);
+        SaveAnnotation(annotation);
 
         if (!editType) {
             setEditType(annotationType);
+        }
+    }
+
+    function SaveAnnotation(annotation) {
+        if (annotation) {
+            annotation['target']['id'] = `https://hdl.handle.net/${targetId}`
+
+            InsertAnnotation(annotation, UserService.getToken(), Process);
+
+            function Process(result) {
+                if (result) {
+                    const copyModalAnnotations = { ...modalAnnotations };
+
+                    if (!copyModalAnnotations[modalProperty['property']]) {
+                        copyModalAnnotations[modalProperty['property']] = { [result['motivation']]: { [result['creator']]: result } }
+                    } else if (!copyModalAnnotations[modalProperty['property']][result['motivation']]) {
+                        copyModalAnnotations[modalProperty['property']][result['motivation']] = { [result['creator']]: result };
+                    } else {
+                        copyModalAnnotations[modalProperty['property']][result['motivation']][result['creator']] = result;
+                    }
+
+                    props.SetModalAnnotations(copyModalAnnotations);
+                }
+            }
+        }
+    }
+
+    function RemoveAnnotation(type) {
+        const annotation = modalAnnotations[modalProperty['property']][type][UserService.getSubject()];
+
+        DeleteAnnotation(annotation['id'], UserService.getToken(), Process);
+
+        function Process(success) {
+            if (success) {
+                const copyModalAnnotations = { ...modalAnnotations };
+
+                delete copyModalAnnotations[modalProperty['property']][type][annotation['creator']];
+
+                props.SetModalAnnotations(copyModalAnnotations);
+            }
         }
     }
 
@@ -238,7 +306,7 @@ const AnnotateModal = (props) => {
 
                             UpdateFormData={(annotationType, formField, value) => UpdateFormData(annotationType, formField, value)}
                             SubmitForm={(annotationType) => SubmitForm(annotationType)}
-                            RemoveAnnotation={(annotation) => props.RemoveAnnotation(annotation)}
+                            RemoveAnnotation={(annotation) => RemoveAnnotation(annotation)}
                         />);
                     case 'linking':
                         return (<LinkingForm
@@ -248,7 +316,7 @@ const AnnotateModal = (props) => {
 
                             UpdateFormData={(annotationType, formField, value) => UpdateFormData(annotationType, formField, value)}
                             SubmitForm={(annotationType) => SubmitForm(annotationType)}
-                            RemoveAnnotation={(annotation) => props.RemoveAnnotation(annotation)}
+                            RemoveAnnotation={(annotation) => RemoveAnnotation(annotation)}
                         />);
                     case 'correcting':
                         return (<CorrectingForm
@@ -258,7 +326,7 @@ const AnnotateModal = (props) => {
 
                             UpdateFormData={(annotationType, formField, value) => UpdateFormData(annotationType, formField, value)}
                             SubmitForm={(annotationType) => SubmitForm(annotationType)}
-                            RemoveAnnotation={(annotation) => props.RemoveAnnotation(annotation)}
+                            RemoveAnnotation={(annotation) => RemoveAnnotation(annotation)}
                         />);
                     case 'quality_flagging':
                         return (<QualityFlaggingForm
@@ -268,7 +336,7 @@ const AnnotateModal = (props) => {
 
                             UpdateFormData={(annotationType, formField, value) => UpdateFormData(annotationType, formField, value)}
                             SubmitForm={(annotationType) => SubmitForm(annotationType)}
-                            RemoveAnnotation={(annotation) => props.RemoveAnnotation(annotation)}
+                            RemoveAnnotation={(annotation) => RemoveAnnotation(annotation)}
                         />);
                     case 'adding':
                         return (<AddingForm
@@ -278,7 +346,7 @@ const AnnotateModal = (props) => {
 
                             UpdateFormData={(annotationType, formField, value) => UpdateFormData(annotationType, formField, value)}
                             SubmitForm={(annotationType) => SubmitForm(annotationType)}
-                            RemoveAnnotation={(annotation) => props.RemoveAnnotation(annotation)}
+                            RemoveAnnotation={(annotation) => RemoveAnnotation(annotation)}
                             RenderMultipleMode={(annotationType) => RenderMultipleMode(annotationType)}
                         />);
                 }
@@ -293,7 +361,7 @@ const AnnotateModal = (props) => {
 
                     UpdateFormData={(annotationType, formField, value) => UpdateFormData(annotationType, formField, value)}
                     SubmitForm={(annotationType) => SubmitForm(annotationType)}
-                    RemoveAnnotation={(type) => props.RemoveAnnotation(type)}
+                    RemoveAnnotation={(type) => RemoveAnnotation(type)}
                 />);
             }
         }

--- a/src/templates/specimen/body/annotate/AnnotateRow.js
+++ b/src/templates/specimen/body/annotate/AnnotateRow.js
@@ -16,7 +16,7 @@ const AnnotateRow = (props) => {
         <Row>
             <Col md={{ span: 12 }} className="mt-4 border-l-1-primary">
                 <Row>
-                    <Col md={{ span: 4 }} className="annotate_annotateSectionTitle border-dark border-bottom" onClick={() => props.ToggleAnnotationRow(group)}>
+                    <Col md={{ span: 4 }} className="annotate_annotateSectionTitle fw-bold border-dark border-bottom" onClick={() => props.ToggleAnnotationRow(group)}>
                         {group + ' data'}
                         <FontAwesomeIcon
                             icon={faChevronDown}

--- a/src/templates/specimen/body/annotate/AnnotateSection.js
+++ b/src/templates/specimen/body/annotate/AnnotateSection.js
@@ -3,9 +3,6 @@ import { Row, Col } from 'react-bootstrap';
 import UserService from 'keycloak/Keycloak';
 import './annotate.scss';
 
-/* Import API */
-import InsertAnnotation from 'api/annotate/InsertAnnotation';
-import DeleteAnnotation from 'api/annotate/DeleteAnnotation';
 
 /* Import Components */
 import AnnotateRow from './AnnotateRow';
@@ -18,65 +15,6 @@ const AnnotateSection = (props) => {
     const modalProperty = props.modalProperty;
     const modalAnnotations = props.modalAnnotations;
     const annotationType = props.annotationType;
-
-    const token = UserService.getToken();
-
-    const annotationTypes = [{
-        key: "commenting",
-        displayName: "Commenting"
-    }, {
-        key: "linking",
-        displayName: "Relationship/Link"
-    }, {
-        key: "correcting",
-        displayName: "Error correction"
-    }, {
-        key: "quality_flagging",
-        displayName: "Quality flag"
-    }, {
-        key: "adding",
-        displayName: "Addition"
-    }];
-
-    function SaveAnnotation(annotation) {
-        if (annotation) {
-            annotation['target']['id'] = `https://hdl.handle.net/${specimen['Meta']['id']['value']}`
-
-            InsertAnnotation(annotation, token, Process);
-
-            function Process(result) {
-                if (result) {
-                    const copyModalAnnotations = { ...modalAnnotations };
-
-                    if (!copyModalAnnotations[modalProperty['property']]) {
-                        copyModalAnnotations[modalProperty['property']] = { [result['motivation']]: { [result['creator']]: result } }
-                    } else if (!copyModalAnnotations[modalProperty['property']][result['motivation']]) {
-                        copyModalAnnotations[modalProperty['property']][result['motivation']] = { [result['creator']]: result };
-                    } else {
-                        copyModalAnnotations[modalProperty['property']][result['motivation']][result['creator']] = result;
-                    }
-
-                    props.SetModalAnnotations(copyModalAnnotations);
-                }
-            }
-        }
-    }
-
-    function RemoveAnnotation(type) {
-        const annotation = modalAnnotations[modalProperty['property']][type][UserService.getSubject()];
-
-        DeleteAnnotation(annotation['id'], token, Process);
-
-        function Process(success) {
-            if (success) {
-                const copyModalAnnotations = { ...modalAnnotations };
-
-                delete copyModalAnnotations[modalProperty['property']][type][annotation['creator']];
-
-                props.SetModalAnnotations(copyModalAnnotations);
-            }
-        }
-    }
 
     const [toggledAnnotationRows, setToggledAnnotationRows] = useState({ Meta: 'active' });
 
@@ -120,17 +58,17 @@ const AnnotateSection = (props) => {
 
             {UserService.isLoggedIn() &&
                 <AnnotateModal
+                    targetId={specimen['Meta']['id']['value']}
+                    targetType={'digital_specimen'}
+
                     modalToggle={modalToggle}
                     modalAnnotations={modalAnnotations}
                     modalProperty={modalProperty}
                     annotationType={annotationType}
-                    annotationTypes={annotationTypes}
 
                     ToggleModal={() => props.ToggleModal()}
-                    SaveAnnotation={(annotation) => SaveAnnotation(annotation)}
-                    // UpdateAnnotation={(annotation, propertyKey) => UpdateAnnotation(annotation, propertyKey)}
-                    RemoveAnnotation={(annotation) => RemoveAnnotation(annotation)}
                     SetAnnotationType={(type, form) => props.SetAnnotationType(type, form)}
+                    SetModalAnnotations={(modalAnnotations) => props.SetModalAnnotations(modalAnnotations)}
                 />
             }
         </div >

--- a/src/templates/specimen/body/annotationsOverview/AnnotationsOverview.js
+++ b/src/templates/specimen/body/annotationsOverview/AnnotationsOverview.js
@@ -52,7 +52,8 @@ const AnnotationsOverview = (props) => {
     const Events = (annotation) => {
         const propertyObject = AnnotationFilterLayer[annotation['target']['indvProp']];
 
-        props.ToggleModal(propertyObject, annotation['target']['indvProp'], annotation['motivation'])
+        console.log(propertyObject);
+        props.ToggleModal(propertyObject, annotation['target']['indvProp'], annotation['motivation']);
     }
 
     if (overviewAnnotations) {

--- a/src/templates/specimen/body/specimenMedia/SpecimenMedia.js
+++ b/src/templates/specimen/body/specimenMedia/SpecimenMedia.js
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { Row, Col } from 'react-bootstrap';
 
 
@@ -27,11 +28,13 @@ const SpecimenMedia = (props) => {
                                             alt={'Specimen ' + i}
                                         />
 
-                                        <div className="specimen_mediaCover p-5 position-absolute w-100 h-100 fw-bold text-white text-center">
-                                            Media Cover
-                                            <br />
-                                            Click for more information
-                                        </div>
+                                        <Link to={`/dm/${mediaItem['id']}`}>
+                                            <div className="specimen_mediaCover p-5 position-absolute w-100 h-100 fw-bold text-white text-center">
+                                                Media Cover
+                                                <br />
+                                                Click for more information
+                                            </div>
+                                        </Link>
                                     </div>
                                 </Col>
                             );


### PR DESCRIPTION
This PR adds a view for the Digital Media Item that can be accessed through it's own unique URL. This page allows the user to see the digital media item and also to click through the other media items associated with the target specimen. Annotating media metadata is possible through the same annotation modal as on the specimen page, additionally a beginning for visual annotating of images has been added.

The annotation modal's code has been reworked a bit so it is easier to include this component in other pages as well. In the future it is probably more usefull to create a seperate folder for these kind of components instead of including it from the annotate folder that is nested in the specimen folder.