### PR TITLE
Add Harmonized Fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "html-react-parser": "^3.0.4",
         "i18next": "^22.4.10",
         "keycloak-js": "^18.0.0",
+        "leaflet": "^1.9.3",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "msw": "^1.1.0",
@@ -40,6 +41,7 @@
         "react-datepicker": "^4.10.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^12.2.0",
+        "react-leaflet": "^4.2.1",
         "react-mark-image": "^0.2.3",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.3.0",
@@ -53,6 +55,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.3",
         "@types/lodash": "^4.14.192",
         "@types/react-datepicker": "^4.8.0"
       }
@@ -3384,6 +3387,16 @@
         }
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.1.tgz",
@@ -4155,6 +4168,12 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -4229,6 +4248,15 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-Caa1lYOgKVqDkDZVWkto2Z5JtVo09spEaUt2S69LiugbBpoqQu92HYFMGUbYezZbnBkyOxMNPXHSgRrRY5UyIA==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/lodash": {
       "version": "4.14.192",
@@ -12617,6 +12645,11 @@
         "language-subtag-registry": "^0.3.20"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -15652,6 +15685,19 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "html-react-parser": "^3.0.4",
     "i18next": "^22.4.10",
     "keycloak-js": "^18.0.0",
+    "leaflet": "^1.9.3",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "msw": "^1.1.0",
@@ -35,6 +36,7 @@
     "react-datepicker": "^4.10.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^12.2.0",
+    "react-leaflet": "^4.2.1",
     "react-mark-image": "^0.2.3",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.3.0",
@@ -75,6 +77,7 @@
     ]
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.3",
     "@types/lodash": "^4.14.192",
     "@types/react-datepicker": "^4.8.0"
   }

--- a/src/api/annotate/InsertAnnotation.ts
+++ b/src/api/annotate/InsertAnnotation.ts
@@ -12,13 +12,20 @@ const InsertAnnotation = async (annotationRecord: AnnotationTemplate, token?: st
     if (annotationRecord && token) {
         let annotation = <Annotation>{};
 
+        const postAnnotation = {
+            data: {
+                type: 'annotation',
+                attributes: annotationRecord
+            }
+        };
+
         const endPoint = '/annotations';
 
         try {
             const result = await axios({
                 method: "post",
                 url: endPoint,
-                data: annotationRecord,
+                data: postAnnotation,
                 responseType: 'json',
                 headers: {
                     'Content-type': 'application/json',

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -56,7 +56,7 @@ const Home = () => {
                                         <Tab className={classTab} selectedClassName={styles.active}> Digital Specimen ID  </Tab>
                                         <Tab className={classTab} selectedClassName={styles.active}> Physical Specimen ID </Tab>
                                         <Tab className={classTab} selectedClassName={styles.active}> Collection facility </Tab>
-                                        <Tab className={classTab} selectedClassName={styles.active}> Virtual colletion </Tab>
+                                        <Tab className={classTab} selectedClassName={styles.active}> Virtual collection </Tab>
                                     </TabList>
 
                                     {/* Search by Digital Specimen */}

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -118,7 +118,7 @@ const Specimen = () => {
                                     <IDCard ToggleModal={(property: string) => ToggleModal(property)} />
                                 </Col>
                                 <Col md={{ span: 9 }} className="ps-5 h-100">
-                                    <ContentBlock />
+                                    <ContentBlock ToggleModal={(property: string) => ToggleModal(property)} />
                                 </Col>
 
                                 {(Object.keys(annotateTarget.target).length > 0 && KeycloakService.IsLoggedIn()) &&

--- a/src/components/specimen/components/IDCard/IDCard.tsx
+++ b/src/components/specimen/components/IDCard/IDCard.tsx
@@ -116,7 +116,7 @@ const IDCard = (props: Props) => {
                                                 <Col className="col-md-auto">
                                                     <Row>
                                                         <Col className={`${styles.IDCardPropertyBlock} rounded-c`}
-                                                            onClick={() => ToggleModal('physicalSpecimenId')}
+                                                            onClick={() => ToggleModal('ods:physicalSpecimenId')}
                                                         >
                                                             <p className={`${styles.IDCardProperty} text-primary m-0`}> Physical Specimen ID ({specimen.physicalSpecimenIdType}): </p>
                                                             <p role="modalTriggerProperty" className={`${styles.IDCardValue} m-0`}> {specimen.physicalSpecimenId} </p>

--- a/src/components/specimen/components/contentBlock/ContentBlock.tsx
+++ b/src/components/specimen/components/contentBlock/ContentBlock.tsx
@@ -17,7 +17,15 @@ import DigitalMedia from './DigitalMedia';
 import MIDSOverview from './MIDSOverview';
 
 
-const ContentBlock = () => {
+/* Props Typing */
+interface Props {
+    ToggleModal: Function
+};
+
+
+const ContentBlock = (props: Props) => {
+    const { ToggleModal } = props;
+
     /* Base variables */
     const specimen = useAppSelector(getSpecimen);
 
@@ -42,7 +50,7 @@ const ContentBlock = () => {
                     <Col className="h-100">
                         <Tabs defaultActiveKey="digitalSpecimen" className={`${styles.tabs}`}>
                             <Tab eventKey="digitalSpecimen" title="Digital Specimen" className="h-100 pt-4">
-                                <SpecimenOverview />
+                                <SpecimenOverview ToggleModal={(property: string) => ToggleModal(property)} />
                             </Tab>
                             <Tab eventKey="originalData" title="Original Data">
                                 <OriginalData />

--- a/src/components/specimen/components/contentBlock/SpecimenOverview.tsx
+++ b/src/components/specimen/components/contentBlock/SpecimenOverview.tsx
@@ -1,15 +1,32 @@
 /* Import Dependencies */
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import { Icon } from 'leaflet';
 import { Row, Col, Card } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector } from 'app/hooks';
 import { getSpecimen } from "redux/specimen/SpecimenSlice";
 
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faLandmark, faLocationDot, faBoxArchive } from '@fortawesome/free-solid-svg-icons';
+
 /* Import Styles */
 import styles from 'components/specimen/specimen.module.scss';
 
+/* Import Sources */
+import markerIconPng from "leaflet/dist/images/marker-icon.png"
 
-const SpecimenOverview = () => {
+
+/* Props Typing */
+interface Props {
+    ToggleModal: Function
+};
+
+
+const SpecimenOverview = (props: Props) => {
+    const { ToggleModal } = props;
+
     /* Base variables */
     const specimen = useAppSelector(getSpecimen);
 
@@ -23,127 +40,195 @@ const SpecimenOverview = () => {
     };
 
     return (
-        <Row className="h-100">
+        <Row className="h-100 overflow-scroll">
             <Col>
                 <Row className="h-50">
                     {/* Location */}
-                    <Col md={{ span: 7 }} className="pb-2">
+                    <Col md={{ span: 12 }} className="pb-2">
                         <Card className="position-relative h-100">
                             <Card.Body>
-                                <Card.Title>
-                                    Location
-                                </Card.Title>
+                                <Row className="h-100">
+                                    <Col md={{ span: 4 }}>
+                                        <Card.Title>
+                                            <FontAwesomeIcon icon={faLocationDot} />
+                                            <span className="ms-1"> Location </span>
+                                        </Card.Title>
 
-                                <Row className="mt-3">
-                                    <Col>
-                                        Country: Coming Soon
+                                        <Row className="mt-3">
+                                            <Col>
+                                                <Row>
+                                                    <Col>
+                                                        <table className={styles.propertyTable}>
+                                                            <tr>
+                                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                                    onClick={() => ToggleModal('dwc:continent')}
+                                                                >
+                                                                    <td className={`${styles.propertyTitle} pe-2`}> Continent: </td>
+                                                                    <td>
+                                                                        {specimen.data['dwc:continent'] ?
+                                                                            specimen.data['dwc:continent']
+                                                                            : 'Not provided'
+                                                                        }
+                                                                    </td>
+                                                                </div>
+                                                            </tr>
+                                                            <tr onClick={() => ToggleModal('dwc:country')}>
+                                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                                    onClick={() => ToggleModal('dwc:country')}
+                                                                >
+                                                                    <td className={`${styles.propertyTitle} pe-2`}> Country: </td>
+                                                                    <td>
+                                                                        {specimen.data['dwc:country'] ?
+                                                                            specimen.data['dwc:country']
+                                                                            : 'Not provided'
+                                                                        }
+                                                                    </td>
+                                                                </div>
+                                                            </tr>
+                                                            <tr onClick={() => ToggleModal('dwc:locality')}>
+                                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                                    onClick={() => ToggleModal('dwc:locality')}
+                                                                >
+                                                                    <td className={`${styles.propertyTitle} pe-2`}> Locality: </td>
+                                                                    <td>
+                                                                        {specimen.data['dwc:locality'] ?
+                                                                            specimen.data['dwc:locality']
+                                                                            : 'Not provided'
+                                                                        }
+                                                                    </td>
+                                                                </div>
+                                                            </tr>
+                                                        </table>
+                                                    </Col>
+                                                </Row>
+                                            </Col>
+                                        </Row>
                                     </Col>
-                                </Row>
-                                <Row className="mt-2">
-                                    <Col>
-                                        Locality: Coming Soon
-                                    </Col>
-                                </Row>
-                                <Row className="mt-2">
-                                    <Col>
-                                        Others: Other fields
+                                    <Col md={{ span: 8 }} className="h-100">
+                                        {(specimen.data['dwc:decimalLatitude'] && specimen.data['dwc:decimalLongitude']) ?
+                                            <MapContainer center={[specimen.data['dwc:decimalLatitude'], specimen.data['dwc:decimalLongitude']]}
+                                                zoom={13} scrollWheelZoom={false} style={{ width: "100%", height: "100%" }}
+                                            >
+                                                <TileLayer
+                                                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                                                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                                                />
+
+                                                <Marker position={[specimen.data['dwc:decimalLatitude'], specimen.data['dwc:decimalLongitude']]}
+                                                    icon={new Icon({ iconUrl: markerIconPng, iconSize: [25, 41], iconAnchor: [12, 41] })}
+                                                >
+                                                    <Popup>
+                                                        <p className="fw-bold m-0"> Coordinates </p>
+                                                        <p className="mt-1 mb-0"> Latitude: {specimen.data['dwc:decimalLatitude']} </p>
+                                                        <p className="mt-1"> Longitude: {specimen.data['dwc:decimalLongitude']} </p>
+                                                    </Popup>
+                                                </Marker>
+                                            </MapContainer>
+                                            : <div className={`${styles.mapPlaceholder} w-100 h-100 d-flex align-items-center
+                                                justify-content-center fst-italic`}
+                                            >
+                                                Map can not be generated due to lack of coordinates
+                                            </div>
+                                        }
                                     </Col>
                                 </Row>
                             </Card.Body>
-
-                            {/* Map */}
-                            <div className="position-absolute w-50 h-100 bg-primary-dark end-0 text-center">
-                                <h2 className="text-white"> Map </h2>
-                            </div>
-                        </Card>
-                    </Col>
-                    <Col md={{ span: 5 }} className="pb-2">
-                        <Card className="position-relative h-100">
-                            <Card.Body>
-                                <Card.Title>
-                                    Organisation
-                                </Card.Title>
-
-                                <Row className="mt-3">
-                                    <Col>
-                                        Name: Coming Soon
-                                    </Col>
-                                </Row>
-                                <Row className="mt-2">
-                                    <Col>
-                                        Country: Coming Soon
-                                    </Col>
-                                </Row>
-                                <Row className="mt-2">
-                                    <Col>
-                                        Others: Other fields
-                                    </Col>
-                                </Row>
-                            </Card.Body>
-
-                            {specimen.organisationId &&
-                                <>
-                                    {logo(specimen.organisationId.replace('https://ror.org/', '')) &&
-                                        <div className="position-absolute w-100 h-100 end-0 text-center d-flex justify-content-end">
-                                            <img alt="organisation logo"
-                                                src={logo(specimen.organisationId.replace('https://ror.org/', ''))}
-                                                className={`${styles.organisationLogo} h-100`}
-                                            />
-                                        </div>
-                                    }
-                                </>
-                            }
                         </Card>
                     </Col>
                 </Row>
                 <Row className="h-50">
                     {/* Taxa */}
-                    <Col md={{ span: 4 }} className="pt-2">
+                    <Col md={{ span: 6 }} className="pt-2">
                         <Card className="h-100">
                             <Card.Body>
                                 <Card.Title>
-                                    Taxa
+                                    <FontAwesomeIcon icon={faLandmark} />
+                                    <span className="ms-1"> Organisation </span>
                                 </Card.Title>
 
                                 <Row className="mt-3">
                                     <Col>
-                                        Clade: Coming Soon
-                                    </Col>
-                                </Row>
-                                <Row className="mt-2">
-                                    <Col>
-                                        Family: Coming Soon
-                                    </Col>
-                                </Row>
-                                <Row className="mt-2">
-                                    <Col>
-                                        Others: Other fields
+                                        <table className={styles.propertyTable}>
+                                            <tr>
+                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                    onClick={() => ToggleModal('ods:organisationId')}
+                                                >
+                                                    <td className={`${styles.propertyTitle} pe-2`}> ROR: </td>
+                                                    <td> {specimen.organisationId} </td>
+                                                </div>
+                                            </tr>
+                                            <tr>
+                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                    onClick={() => ToggleModal('ods:organisationName')}
+                                                >
+                                                    <td className={`${styles.propertyTitle} pe-2`}> Name: </td>
+                                                    <td> {specimen.data['ods:organisationName']} </td>
+                                                </div>
+                                            </tr>
+                                        </table>
+
+                                        <div className="position-absolute d-flex justify-content-end bottom-0 z-0">
+                                            <img src={logo(specimen.data['ods:organisationId'].replace('https://ror.org/', ''))}
+                                                className={styles.organisationLogo}
+                                            />
+                                        </div>
                                     </Col>
                                 </Row>
                             </Card.Body>
                         </Card>
                     </Col>
                     {/* Other details */}
-                    <Col md={{ span: 8 }} className="pt-2">
+                    <Col md={{ span: 6 }} className="pt-2">
                         <Card className="h-100">
                             <Card.Body>
                                 <Card.Title>
-                                    Other details...
+                                    <FontAwesomeIcon icon={faBoxArchive} />
+                                    <span className="ms-1"> Collection </span>
                                 </Card.Title>
 
                                 <Row className="mt-3">
                                     <Col>
-                                        Property: value
-                                    </Col>
-                                </Row>
-                                <Row className="mt-2">
-                                    <Col>
-                                        Property: value
-                                    </Col>
-                                </Row>
-                                <Row className="mt-2">
-                                    <Col>
-                                        Others: Other fields
+                                        <table className={styles.propertyTable}>
+                                            <tr>
+                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                    onClick={() => ToggleModal('ods:collectingNumber')}
+                                                >
+                                                    <td className={`${styles.propertyTitle} pe-2`}> Collecting Number: </td>
+                                                    <td>
+                                                        {specimen.data['ods:collectingNumber'] ?
+                                                            specimen.data['ods:collectingNumber']
+                                                            : 'Not provided'
+                                                        }
+                                                    </td>
+                                                </div>
+                                            </tr>
+                                            <tr>
+                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                    onClick={() => ToggleModal('ods:collector')}
+                                                >
+                                                    <td className={`${styles.propertyTitle} pe-2`}> Collector: </td>
+                                                    <td>
+                                                        {specimen.data['ods:collector'] ?
+                                                            specimen.data['ods:collector']
+                                                            : 'Not provided'
+                                                        }
+                                                    </td>
+                                                </div>
+                                            </tr>
+                                            <tr>
+                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                    onClick={() => ToggleModal('ods:dateCollected')}
+                                                >
+                                                    <td className={`${styles.propertyTitle} pe-2`}> Date Collected: </td>
+                                                    <td>
+                                                        {specimen.data['ods:dateCollected'] ?
+                                                            specimen.data['ods:dateCollected']
+                                                            : 'Not provided'
+                                                        }
+                                                    </td>
+                                                </div>
+                                            </tr>
+                                        </table>
                                     </Col>
                                 </Row>
                             </Card.Body>

--- a/src/components/specimen/components/contentBlock/VersionSelect.tsx
+++ b/src/components/specimen/components/contentBlock/VersionSelect.tsx
@@ -43,8 +43,10 @@ const VersionSelect = () => {
     return (
         <Row>
             <Col>
-                <Select defaultValue={{ value: specimen.version, label: `Version ${specimen.version}` }}
+                <Select 
+                    defaultValue={{ value: specimen.version, label: `Version ${specimen.version}` }}
                     options={selectOptions}
+                    styles={{ menu: provided => ({ ...provided, zIndex: 100000 }) }}
                     onChange={(option) => { option?.value && dispatch(setSpecimenVersion(option.value)) }}
                 />
             </Col>

--- a/src/components/specimen/specimen.module.scss
+++ b/src/components/specimen/specimen.module.scss
@@ -67,7 +67,6 @@
 .versionBlock {
     height: 40px;
     position: absolute;
-    z-index: 1;
 }
 
 .versionBlock.active {
@@ -122,9 +121,39 @@
 
 /* Digital Specimen Block */
 
+.propertyTable {
+    border-collapse: separate;
+    border-spacing: 0px 4px;
+    position: relative;
+    width: 100%;
+    z-index: 1;
+}
+
+.propertyTableRow {
+    transition: 0.3s;
+    cursor: pointer;
+    border-radius: 8px;
+}
+
+.propertyTableRow:hover {
+    background-color: var(--main-color-light);
+}
+
+.propertyTitle {
+    color: var(--main-color);
+    font-weight: bold;
+    text-align: start;
+}
+
+.mapPlaceholder {
+    background-color: var(--main-color-light);
+}
+
 .organisationLogo {
     filter: grayscale(100%);
     opacity: 0.4;
+    width: 50%;
+    margin: 0px 10px 10px 0px;
 }
 
 /* Original Data Block */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import './i18n';
 /* Import Styles */
 import 'bootstrap/dist/css/bootstrap.min.css';
 import "react-datepicker/dist/react-datepicker.css";
+import 'leaflet/dist/leaflet.css'
 
 /* Import Components */
 import App from './App';


### PR DESCRIPTION
Commit adds harmonized fields to the specimen overview tab on the Specimen Page. These harmonized fields should demonstrate how we can display values conform different categories like: location, organisation and collection. Harmonized fields are annotatable.

Commit also adds a Leaflet map that can be generated based on the coordinates of the specimen. A placeholder will be shown if the latitude or longitude is missing.

Adds:
- Couple of harmonized fields to display how we can handle this (annotatable)
- Leaflet (OpenStreet) map based upon the coordinates of the specimen

Bug fixes:
- Cannot annotate physical specimen id due to its missing prefix 'ods:'  in the code