### PR TITLE
Expand ID Card feature to Search Page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,8 @@
 /* Declaring global variables */
 :root {
+  --primary: #4d59a2;
+  --secondary: #51a993;
+  --accent: #28bacb;
   --main-color: #0C86C6;
   --main-color-light: #d6e0f5;
   --main-color-dark: #1c497d;
@@ -63,6 +66,11 @@ p {
 
 
 /* Custom additional styling */
+
+/* Width */
+.w-0 {
+  width: 0px;
+}
 
 /* Color */
 
@@ -217,6 +225,11 @@ p {
   box-shadow: 5px 2px 11px 2px rgba(0, 0, 0, 0.54);
 }
 
+/* Transition */
+.transition {
+  transition: 0.4s;
+}
+
 
 /* Custom Component Styling */
 
@@ -284,6 +297,11 @@ p {
 .tab-pane {
   height: 100%;
   padding-top: 2%;
+}
+
+li.page-item.active .page-link {
+  background-color: var(--secondary);
+  border: none;
 }
 
 

--- a/src/api/specimen/GetRecentSpecimens.ts
+++ b/src/api/specimen/GetRecentSpecimens.ts
@@ -17,6 +17,9 @@ const GetRecentSpecimens = async () => {
         const result = await axios({
             method: "get",
             url: endPoint,
+            params: {
+                pageSize: 25
+            },
             responseType: 'json'
         });
 

--- a/src/api/specimen/GetSpecimenAggregations.ts
+++ b/src/api/specimen/GetSpecimenAggregations.ts
@@ -2,13 +2,30 @@
 import axios from 'axios';
 
 /* Import Types */
-import { JSONResult, Dict } from 'global/Types';
+import { JSONResult, SearchFilter, Dict } from 'global/Types';
 
 
-const GetSpecimenAggregations = async () => {
+const GetSpecimenAggregations = async (searchFilters?: SearchFilter[]) => {
     let aggregations = <Dict>{};
+    let endPoint: string = '/specimens/aggregation';
 
-    const endPoint: string = '/specimens/aggregation';
+    /* If present, destructure Search Filters into string */
+    let filters: string = '';
+
+    if (searchFilters) {
+        searchFilters.forEach((filter, index) => {
+            const filterName = Object.keys(filter)[0];
+            const filterValue = Object.values(filter)[0];
+
+            if (index > 0) {
+                filters = filters.concat(`&${filterName}=${filterValue}`);
+            } else {
+                filters = filters.concat(`${filterName}=${filterValue}`);
+            }
+        });
+
+        endPoint = endPoint.concat(`?${filters}`);
+    }
 
     try {
         const result = await axios({

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -1,13 +1,13 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { isEmpty } from 'lodash';
+import classNames from 'classnames';
 import { Container, Row, Col } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
-import {
-    setSpecimenSearchResults, getSpecimenSearchResults
-} from "redux/search/SearchSlice";
+import { getSpecimenSearchResults, setSpecimenSearchResults, getSearchSpecimen } from "redux/search/SearchSlice";
 
 /* Import Types */
 import { SearchFilter } from 'global/Types';
@@ -21,10 +21,12 @@ import Header from 'components/general/header/Header';
 import SearchMenu from './components/searchMenu/SearchMenu';
 import ResultsTable from './components/searchResults/ResultsTable';
 import Paginator from 'components/general/paginator/Paginator';
+import IDCard from './components/IDCard/IDCard';
 import Footer from 'components/general/footer/Footer';
 
 /* Import API */
 import SearchSpecimens from "api/specimen/SearchSpecimens";
+import GetRecentSpecimens from 'api/specimen/GetRecentSpecimens';
 
 
 const Search = () => {
@@ -34,6 +36,7 @@ const Search = () => {
 
     /* Base variables */
     const specimenSearchResults = useAppSelector(getSpecimenSearchResults);
+    const searchSpecimen = useAppSelector(getSearchSpecimen);
 
     /* OnLoad/OnChange of search params: check filters, then action a search */
     useEffect(() => {
@@ -46,10 +49,18 @@ const Search = () => {
             });
         }
 
-        /* Action Search */
-        SearchSpecimens(searchFilters).then((specimens) => {
-            dispatch(setSpecimenSearchResults(specimens));
-        });
+        /* If any filter is selected */
+        if (!isEmpty(searchFilters)) {
+            /* Action Search */
+            SearchSpecimens(searchFilters).then((specimens) => {
+                dispatch(setSpecimenSearchResults(specimens));
+            });
+        } else {
+            /* Grab Recent Specimens */
+            GetRecentSpecimens().then((recentSpecimens) => {
+                dispatch(setSpecimenSearchResults(recentSpecimens));
+            });
+        }
     }, [searchParams]);
 
     /* Pagination */
@@ -58,31 +69,52 @@ const Search = () => {
     /* TEMPORARY CONSOLE LOG FOR SONAR, needs to be updated when API is updated */
     console.log(paginationRange);
 
+    /* ClassName for Search Menu Block */
+    const classSearchMenu = classNames({
+        'transition': true,
+        'w-0': !isEmpty(searchSpecimen),
+    });
+
+    /* ClassName for Search Results Block */
+    const classSearchResults = classNames({
+        'transition bg-white position-absolute z-1': true,
+        'offset-md-3': isEmpty(searchSpecimen),
+        'w-50': !isEmpty(searchSpecimen)
+    });
+
+    /* ClassName for ID Card Block */
+    const classIDCard = classNames({
+        'transition bg-white position-absolute z-0': true,
+        'w-50': !isEmpty(searchSpecimen)
+    });
+
     return (
         <div className="d-flex flex-column min-vh-100">
             <Header />
 
-            <Container fluid className={`${styles.content} mt-5`}>
+            <Container fluid className={`${styles.searchContent} mt-5`}>
                 <Row className="h-100">
-                    <Col md={{ span: 2 }} className="h-100">
-                        {/* Search Menu */}
-                        <SearchMenu />
-                    </Col>
-                    <Col md={{ span: 10 }} className="h-100">
-                        <Row className="h-100">
-                            {/* Search Results */}
-                            <Col md={{ span: 12 }}>
-                                <Row>
-                                    <Col md={{ span: 12 }} className="search_resultsSection">
+                    {/* Button for toggling filters */}
+                    <Col md={{ span: 10, offset: 1 }} className="h-100">
+                        <Row className="position-relative h-100">
+                            <Col md={{ span: 3 }} className={`${classSearchMenu} h-100`}>
+                                {/* Search Menu */}
+                                <SearchMenu />
+                            </Col>
+                            <Col md={{ span: 9 }} className={`${classSearchResults} h-100`}>
+                                <Row className={`${styles.searchResults} `}>
+                                    {/* Search Results */}
+
+                                    <Col md={{ span: 12 }} className="h-100 pb-2">
                                         <ResultsTable />
                                     </Col>
                                 </Row>
 
-                                <Row className="px-5 mt-3">
-                                    <Col className="search_resultCount col-md-auto py-2">
+                                <Row className={`${styles.paginator} justify-content-center position-relative`}>
+                                    <Col className="search_resultCount col-md-auto py-2 position-absolute start-0 ps-4">
                                         {(specimenSearchResults.length === 1) ?
-                                            '1 specimen found'
-                                            : `${specimenSearchResults.length} specimens found`
+                                            <p className="fst-italic"> 1 specimen found </p>
+                                            : <p className="fst-italic"> {specimenSearchResults.length} specimens found </p>
                                         }
                                     </Col>
 
@@ -96,6 +128,12 @@ const Search = () => {
                                         </Col>
                                     }
                                 </Row>
+                            </Col>
+                            <Col md={{ span: 6, offset: 6 }} className={`${classIDCard} h-100 pb-2`}>
+                                {/* ID Card */}
+                                {!isEmpty(searchSpecimen) &&
+                                    <IDCard />
+                                }
                             </Col>
                         </Row>
                     </Col>

--- a/src/components/search/components/IDCard/IDCard.tsx
+++ b/src/components/search/components/IDCard/IDCard.tsx
@@ -1,6 +1,9 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import { useMap } from 'react-leaflet';
+import { Icon, LatLngExpression } from 'leaflet';
 import { Row, Col, Card } from 'react-bootstrap';
 
 /* Import Store */
@@ -12,6 +15,9 @@ import { DigitalMedia } from 'global/Types';
 
 /* Import Styles */
 import styles from 'components/search/search.module.scss';
+
+/* Import Sources */
+import markerIconPng from "leaflet/dist/images/marker-icon.png"
 
 /* Import Icons */
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -49,6 +55,12 @@ const IDCard = () => {
         } else {
             return '';
         }
+    }
+
+    const ChangeView = ({ center, zoom }: {center: LatLngExpression, zoom: number}) => {
+        const map = useMap();
+        map.setView(center, zoom);
+        return null;
     }
 
     return (
@@ -114,8 +126,37 @@ const IDCard = () => {
             </Row>
             <Row className={styles.IDCardBottom}>
                 <Col className="h-100">
+                    {/*  If present, show Geological Location */}
+                    <Row className={styles.geoLocationBlock}>
+                        <Col>
+                            {(specimen.data['dwc:decimalLatitude'] && specimen.data['dwc:decimalLongitude']) &&
+                                <MapContainer center={[specimen.data['dwc:decimalLatitude'], specimen.data['dwc:decimalLongitude']]}
+                                    zoom={13} scrollWheelZoom={false} style={{ width: "100%", height: "100%" }}
+                                >
+                                    <ChangeView center={[specimen.data['dwc:decimalLatitude'], specimen.data['dwc:decimalLongitude']]}
+                                        zoom={13}
+                                    />
+                                    <TileLayer
+                                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                                    />
+
+                                    <Marker position={[specimen.data['dwc:decimalLatitude'], specimen.data['dwc:decimalLongitude']]}
+                                        icon={new Icon({ iconUrl: markerIconPng, iconSize: [25, 41], iconAnchor: [12, 41] })}
+                                    >
+                                        <Popup>
+                                            <p className="fw-bold m-0"> Coordinates </p>
+                                            <p className="mt-1 mb-0"> Latitude: {specimen.data['dwc:decimalLatitude']} </p>
+                                            <p className="mt-1"> Longitude: {specimen.data['dwc:decimalLongitude']} </p>
+                                        </Popup>
+                                    </Marker>
+                                </MapContainer>
+                            }
+                        </Col>
+                    </Row>
+
                     {/* If present, show Digital Media */}
-                    <Row className={styles.digitalMediaBlock}>
+                    <Row className={`${styles.digitalMediaBlock} pt-2`}>
                         <Col className="h-100">
                             <div className={`${styles.digitalMediaSlider} h-100 w-auto`}>
                                 {digitalMedia.map((mediaItem) => {

--- a/src/components/search/components/IDCard/IDCard.tsx
+++ b/src/components/search/components/IDCard/IDCard.tsx
@@ -40,6 +40,17 @@ const IDCard = () => {
         });
     }, [specimen]);
 
+    /* Function for displaying the Organisation of a Specimen */
+    const OrganisationProperty = () => {
+        if (specimen.data['ods:organisationName']) {
+            return specimen.data['ods:organisationName'];
+        } else if (specimen.organisationId) {
+            return specimen.organisationId;
+        } else {
+            return '';
+        }
+    }
+
     return (
         <Card className={`${styles.IDCard} px-4 py-3`}>
             <Row className={styles.IDCardTop}>
@@ -95,11 +106,7 @@ const IDCard = () => {
                             </p>
                             <p className={`${styles.IDCardProperty} mt-2`}>
                                 <span className="fw-bold"> Organisation: </span>
-                                {specimen.data['ods:organisationName'] ?
-                                    specimen.data['ods:organisationName']
-                                    : specimen.organisationId ?
-                                        specimen.organisationId : '-'
-                                }
+                                {OrganisationProperty()}
                             </p>
                         </Col>
                     </Row>
@@ -113,7 +120,7 @@ const IDCard = () => {
                             <div className={`${styles.digitalMediaSlider} h-100 w-auto`}>
                                 {digitalMedia.map((mediaItem) => {
                                     return (
-                                        <img src={mediaItem.mediaUrl} className={`${styles.digitalMediaItem} h-100 me-3`} />
+                                        <img key={mediaItem.id} src={mediaItem.mediaUrl} className={`${styles.digitalMediaItem} h-100 me-3`} />
                                     );
                                 })}
                             </div>

--- a/src/components/search/components/IDCard/IDCard.tsx
+++ b/src/components/search/components/IDCard/IDCard.tsx
@@ -1,8 +1,7 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
-import { useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import { Icon, LatLngExpression } from 'leaflet';
 import { Row, Col, Card } from 'react-bootstrap';
 

--- a/src/components/search/components/IDCard/IDCard.tsx
+++ b/src/components/search/components/IDCard/IDCard.tsx
@@ -1,0 +1,139 @@
+/* Import Dependencies */
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Row, Col, Card } from 'react-bootstrap';
+
+/* Import Store */
+import { useAppSelector } from 'app/hooks';
+import { getSearchSpecimen } from 'redux/search/SearchSlice';
+
+/* Import Types */
+import { DigitalMedia } from 'global/Types';
+
+/* Import Styles */
+import styles from 'components/search/search.module.scss';
+
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFrog, faCircleInfo, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+
+/* Import API */
+import GetSpecimenDigitalMedia from 'api/specimen/GetSpecimenDigitalMedia';
+
+
+const IDCard = () => {
+    /* Hooks */
+    const navigate = useNavigate();
+
+    /* Base variables */
+    const specimen = useAppSelector(getSearchSpecimen);
+    const [digitalMedia, setDigitalMedia] = useState<DigitalMedia[]>([]);
+
+    /* OnLoad: Check if Specimen has Digital Media attached to it */
+    useEffect(() => {
+        setDigitalMedia([]);
+
+        GetSpecimenDigitalMedia(specimen.id).then((digitalMedia) => {
+            if (digitalMedia) {
+                setDigitalMedia(digitalMedia);
+            }
+        });
+    }, [specimen]);
+
+    return (
+        <Card className={`${styles.IDCard} px-4 py-3`}>
+            <Row className={styles.IDCardTop}>
+                <Col>
+                    {/* Icon and Title */}
+                    <Row className="align-items-center">
+                        <Col className="col-md-auto h-100 pe-1">
+                            <FontAwesomeIcon icon={faFrog}
+                                className={styles.IDCardIcon}
+                            />
+                        </Col>
+                        <Col>
+                            <h2 className={styles.IDCardTitle}> {specimen.specimenName} </h2>
+                        </Col>
+                    </Row>
+
+                    {/* Specimen Identifier */}
+                    <Row>
+                        <Col>
+                            <p className={styles.IDCardId}> {specimen.id} </p>
+                        </Col>
+                    </Row>
+
+                    {/* MIDS Bar */}
+                    <Row className="mt-2 align-items-center">
+                        <Col className="h-100">
+                            <div className={styles.midsBar}>
+                                <div className={`${styles.midsProgressionLevel} h-100`} />
+                            </div>
+                        </Col>
+                        <Col className="col-md-auto ps-1">
+                            <p className={`${styles.midsTitle} fw-bold`}>
+                                <span className="pe-2"> Level {specimen.midsLevel} </span>
+                                <FontAwesomeIcon icon={faCircleInfo} />
+                            </p>
+                        </Col>
+                    </Row>
+
+                    {/* Specimen Information */}
+                    <Row className="mt-4">
+                        <Col>
+                            <p className={styles.IDCardProperty}>
+                                <span className="fw-bold"> Scientific Name: </span> {specimen.specimenName}
+                            </p>
+                            <p className={`${styles.IDCardProperty} mt-2`}>
+                                <span className="fw-bold"> Specimen Type: </span> {specimen.type}
+                            </p>
+                            <p className={`${styles.IDCardProperty} mt-2`}>
+                                <span className="fw-bold"> Physical Specimen ID ({specimen.physicalSpecimenIdType}): </span> {specimen.physicalSpecimenId}
+                            </p>
+                            <p className={`${styles.IDCardProperty} mt-2`}>
+                                <span className="fw-bold"> Physical Specimen Collection: </span> {specimen.physicalSpecimenCollection}
+                            </p>
+                            <p className={`${styles.IDCardProperty} mt-2`}>
+                                <span className="fw-bold"> Organisation: </span>
+                                {specimen.data['ods:organisationName'] ?
+                                    specimen.data['ods:organisationName']
+                                    : specimen.organisationId ?
+                                        specimen.organisationId : '-'
+                                }
+                            </p>
+                        </Col>
+                    </Row>
+                </Col>
+            </Row>
+            <Row className={styles.IDCardBottom}>
+                <Col className="h-100">
+                    {/* If present, show Digital Media */}
+                    <Row className={styles.digitalMediaBlock}>
+                        <Col className="h-100">
+                            <div className={`${styles.digitalMediaSlider} h-100 w-auto`}>
+                                {digitalMedia.map((mediaItem) => {
+                                    return (
+                                        <img src={mediaItem.mediaUrl} className={`${styles.digitalMediaItem} h-100 me-3`} />
+                                    );
+                                })}
+                            </div>
+                        </Col>
+                    </Row>
+
+                    {/* Specimen Page Button */}
+                    <Row className={styles.buttonBlock}>
+                        <Col className="h-100 d-flex justify-content-end align-items-end">
+                            <button type="button" className={`${styles.specimenButton} fw-bold px-3`}
+                                onClick={() => navigate(`/ds/${specimen.id}`)}
+                            >
+                                See full details <FontAwesomeIcon icon={faChevronRight} />
+                            </button>
+                        </Col>
+                    </Row>
+                </Col>
+            </Row>
+        </Card>
+    );
+}
+
+export default IDCard;

--- a/src/components/search/components/searchMenu/SearchMenu.tsx
+++ b/src/components/search/components/searchMenu/SearchMenu.tsx
@@ -1,12 +1,11 @@
 /* Import Dependencies */
-import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Formik, Form } from 'formik';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
-import { useAppSelector, useAppDispatch } from 'app/hooks';
-import { getSearchAggregations, setSearchAggregations} from 'redux/search/SearchSlice';
+import { useAppSelector } from 'app/hooks';
+import { getSearchAggregations } from 'redux/search/SearchSlice';
 
 /* Import Types */
 import { Dict } from 'global/Types';
@@ -18,13 +17,9 @@ import styles from 'components/search/search.module.scss';
 import SearchBar from './filters/SearchBar';
 import MultiSelectFilter from './filters/MultiSelectFilter';
 
-/* Import API */
-import GetSpecimenAggregations from 'api/specimen/GetSpecimenAggregations';
-
 
 const SearchMenu = () => {
     /* Hooks */
-    const dispatch = useAppDispatch();
     const [searchParams, setSearchParams] = useSearchParams();
 
     /* Base variables */

--- a/src/components/search/components/searchMenu/SearchMenu.tsx
+++ b/src/components/search/components/searchMenu/SearchMenu.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Formik, Form } from 'formik';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col, Card } from 'react-bootstrap';
 
 /* Import Types */
 import { Dict } from 'global/Types';

--- a/src/components/search/components/searchMenu/SearchMenu.tsx
+++ b/src/components/search/components/searchMenu/SearchMenu.tsx
@@ -2,7 +2,11 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Formik, Form } from 'formik';
-import { Row, Col, Card } from 'react-bootstrap';
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Store */
+import { useAppSelector, useAppDispatch } from 'app/hooks';
+import { getSearchAggregations, setSearchAggregations} from 'redux/search/SearchSlice';
 
 /* Import Types */
 import { Dict } from 'global/Types';
@@ -20,10 +24,11 @@ import GetSpecimenAggregations from 'api/specimen/GetSpecimenAggregations';
 
 const SearchMenu = () => {
     /* Hooks */
+    const dispatch = useAppDispatch();
     const [searchParams, setSearchParams] = useSearchParams();
 
     /* Base variables */
-    const [aggregations, setAggregations] = useState<Dict>({});
+    const aggregations = useAppSelector(getSearchAggregations);
     const initialValues: Dict = {
         filters: {
             q: searchParams.get('q') ? searchParams.get('q') : ''
@@ -33,15 +38,6 @@ const SearchMenu = () => {
         'midsLevel', 'license', 'country', 'organisationName',
         'sourceSystemId', 'typeStatus', 'hasMedia'
     ];
-
-    /* OnLoad: Fetch Aggregations to construct filters */
-    useEffect(() => {
-        GetSpecimenAggregations().then((aggregations) => {
-            if (aggregations) {
-                setAggregations(aggregations);
-            }
-        });
-    }, []);
 
     /* For each aggregation, set initial value for form */
     Object.keys(aggregations).forEach((aggregationKey) => {

--- a/src/components/search/components/searchMenu/filters/MultiSelectFilter.tsx
+++ b/src/components/search/components/searchMenu/filters/MultiSelectFilter.tsx
@@ -71,7 +71,7 @@ const MultiSelectFilter = (props: Props) => {
     }, [selectedItems]);
 
     return (
-        <Row className="mt-2">
+        <Row className="mt-2 px-2">
             <Col>
                 <Row>
                     <Col>

--- a/src/components/search/components/searchMenu/filters/SearchBar.tsx
+++ b/src/components/search/components/searchMenu/filters/SearchBar.tsx
@@ -13,7 +13,7 @@ import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 const SearchBar = () => {
     return (
         <Row className={`${styles.filterBlock} h-100`}>
-            <Col md={{ span: 12 }} className="bg-primary pt-3 pb-4 px-4">
+            <Col md={{ span: 12 }} className={`${styles.searchBlock} pt-3 pb-4 px-4`}>
                 <Row>
                     <Col md={{ span: 12 }} className="text-white position-relative">
                         <h6>
@@ -21,7 +21,7 @@ const SearchBar = () => {
                         </h6>
 
                         <Field type="text" name="filters.q"
-                            className="search_searchBar w-100"
+                            className={`${styles.searchBar} w-100`}
                             placeholder="Iguanodon"
                         />
 

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -1,25 +1,31 @@
 /* Import Dependencies */
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { isEmpty } from 'lodash';
 import DataTable, { TableColumn } from 'react-data-table-component';
+
+/* Import Store */
+import { useAppSelector, useAppDispatch } from 'app/hooks';
+import { getSpecimenSearchResults, getSearchSpecimen, setSearchSpecimen } from "redux/search/SearchSlice";
 
 /* Import Types */
 import { Specimen } from 'global/Types';
 
-/* Import Store */
-import { useAppSelector, useAppDispatch } from 'app/hooks';
-import { getSpecimenSearchResults } from "redux/search/SearchSlice";
-import { setSpecimen } from 'redux/specimen/SpecimenSlice';
+/* Import Styles */
+import styles from 'components/search/search.module.scss';
+
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 
 
 const ResultsTable = () => {
-    /* Configure Store */
-    const dispatch = useAppDispatch();
-
     /* Hooks */
-    let navigate = useNavigate();
+    const dispatch = useAppDispatch();
 
     /* Base variables */
     const specimenSearchResults = useAppSelector(getSpecimenSearchResults);
+    const searchSpecimen = useAppSelector(getSearchSpecimen);
+    const [tableData, setTableData] = useState<DataRow[]>([]);
 
     interface DataRow {
         index: number,
@@ -27,7 +33,8 @@ const ResultsTable = () => {
         specimen_name: string,
         country: string,
         specimen_type: string,
-        organisation: string
+        organisation: string,
+        toggleSelected: boolean
     };
 
     /* Function for when clicked on a table row, continue to specimen page */
@@ -35,57 +42,139 @@ const ResultsTable = () => {
         /* Set specimen */
         const specimen: Specimen = specimenSearchResults[row.index];
 
-        dispatch(setSpecimen(specimen));
+        dispatch(setSearchSpecimen(specimen));
 
-        /* Navigate to specimen page, row.id equals specimen identifier */
-        navigate(`/ds/${row.id}`);
+        /* Unselect current Row */
+        const unselectedRow = tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.id !== specimen.id));
+
+        if (unselectedRow) {
+            unselectedRow.toggleSelected = false;
+        }
+
+        /* Select chosen Table Row */
+        const selectedRow = tableData.find((tableRow) => tableRow.id === specimen.id);
+
+        if (selectedRow) {
+            selectedRow.toggleSelected = true;
+        }
+
+        setTableData(tableData);
     }
+
+    /* Function to reset chosen Table Row on close */
+    useEffect(() => {
+        if (isEmpty(searchSpecimen)) {
+            /* Unselect current Row */
+            const unselectedRow = tableData.find((tableRow) => tableRow.toggleSelected);
+
+            if (unselectedRow) {
+                unselectedRow.toggleSelected = false;
+            }
+
+            setTableData(tableData);
+        }
+    }, [searchSpecimen]);
 
     /* Set Datatable columns */
     const tableColumns: TableColumn<DataRow>[] = [{
         name: 'Specimen name',
         selector: row => row.specimen_name,
+        id: 'search_name',
         sortable: true
     }, {
         name: 'Country',
         selector: row => row.country,
+        id: 'search_country',
         sortable: true
     }, {
         name: 'Specimen type',
         selector: row => row.specimen_type,
+        id: 'search_type',
         sortable: true
     }, {
         name: 'Organisation',
         selector: row => row.organisation,
+        id: 'search_organisation',
         sortable: true
     }];
 
-    /* Set table data */
-    const tableData: DataRow[] = [];
+    /* Custom styles for Data Table */
+    const customStyles = {
+        head: {
+            style: {
+                color: 'white',
+                fontSize: '14px'
+            }
+        },
+        headRow: {
+            style: {
+                backgroundColor: '#51a993'
+            }
+        },
+        rows: {
+            style: {
+                minHeight: '40px'
+            },
+            highlightOnHoverStyle: {
+                backgroundColor: '#98cdbf',
+            },
+            stripedStyle: {
+                backgroundColor: '#eef7f4'
+            }
+        }
+    };
 
-    specimenSearchResults.forEach((specimen, i) => {
-        tableData.push({
-            index: i,
-            id: specimen.id,
-            specimen_name: specimen.specimenName,
-            country: 'Country',
-            specimen_type: specimen.type,
-            organisation: specimen.organisationId
+    const conditionalRowStyles = [{
+        when: (row: any) => row.toggleSelected,
+        style: {
+            backgroundColor: "#98cdbf",
+            userSelect: "none"
+        }
+    }];
+
+    /* OnChange of Specimen Search Results: update Table Data */
+    useEffect(() => {
+        const tableData: DataRow[] = [];
+
+        specimenSearchResults.forEach((specimen, i) => {
+            tableData.push({
+                index: i,
+                id: specimen.id,
+                specimen_name: specimen.specimenName,
+                country: specimen.data['dwc:country'] ? specimen.data['dwc:country'] : '-',
+                specimen_type: specimen.type,
+                organisation: specimen.organisationId,
+                toggleSelected: false
+            });
         });
-    });
+
+        setTableData(tableData);
+    }, [specimenSearchResults]);
 
     return (
-        <div className="ps-4 h-100 overflow-auto">
-            <DataTable
-                columns={tableColumns}
-                data={tableData}
-                onRowClicked={(row) => OnSpecimenSelect(row)}
+        <>
+            {!isEmpty(searchSpecimen) &&
+                <button type="button" className={`${styles.returnButton} position-absolute px-3 pt-0`}
+                    onClick={() => dispatch(setSearchSpecimen({} as Specimen))}
+                >
+                    <FontAwesomeIcon icon={faChevronLeft} /> Return
+                </button>
+            }
 
-                striped
-                highlightOnHover
-                pointerOnHover
-            />
-        </div>
+            <div className={`${styles.table} h-100 overflow-auto position-relative`}>
+                <DataTable
+                    columns={tableColumns}
+                    data={tableData}
+                    customStyles={customStyles}
+                    onRowClicked={(row) => OnSpecimenSelect(row)}
+                    conditionalRowStyles={conditionalRowStyles}
+
+                    striped
+                    highlightOnHover
+                    pointerOnHover
+                />
+            </div>
+        </>
     );
 }
 

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -58,7 +58,9 @@ const ResultsTable = () => {
             selectedRow.toggleSelected = true;
         }
 
-        setTableData(tableData);
+        const copyTableData = [...tableData];
+
+        setTableData(copyTableData);
     }
 
     /* Function to reset chosen Table Row on close */
@@ -71,7 +73,9 @@ const ResultsTable = () => {
                 unselectedRow.toggleSelected = false;
             }
 
-            setTableData(tableData);
+            const copyTableData = [...tableData];
+
+            setTableData(copyTableData);
         }
     }, [searchSpecimen]);
 

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -5,7 +5,7 @@ import DataTable, { TableColumn } from 'react-data-table-component';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
-import { getSpecimenSearchResults, getSearchSpecimen, setSearchSpecimen } from "redux/search/SearchSlice";
+import { getSearchResults, getSearchSpecimen, setSearchSpecimen } from "redux/search/SearchSlice";
 
 /* Import Types */
 import { Specimen } from 'global/Types';
@@ -23,7 +23,7 @@ const ResultsTable = () => {
     const dispatch = useAppDispatch();
 
     /* Base variables */
-    const specimenSearchResults = useAppSelector(getSpecimenSearchResults);
+    const searchResults = useAppSelector(getSearchResults);
     const searchSpecimen = useAppSelector(getSearchSpecimen);
     const [tableData, setTableData] = useState<DataRow[]>([]);
 
@@ -40,7 +40,7 @@ const ResultsTable = () => {
     /* Function for when clicked on a table row, continue to specimen page */
     const OnSpecimenSelect = (row: DataRow) => {
         /* Set specimen */
-        const specimen: Specimen = specimenSearchResults[row.index];
+        const specimen: Specimen = searchResults[row.index];
 
         dispatch(setSearchSpecimen(specimen));
 
@@ -136,7 +136,7 @@ const ResultsTable = () => {
     useEffect(() => {
         const tableData: DataRow[] = [];
 
-        specimenSearchResults.forEach((specimen, i) => {
+        searchResults.forEach((specimen, i) => {
             tableData.push({
                 index: i,
                 id: specimen.id,
@@ -149,7 +149,7 @@ const ResultsTable = () => {
         });
 
         setTableData(tableData);
-    }, [specimenSearchResults]);
+    }, [searchResults]);
 
     return (
         <>

--- a/src/components/search/search.module.scss
+++ b/src/components/search/search.module.scss
@@ -88,11 +88,11 @@
 }
 
 .IDCardTop {
-    height: 60%;
+    height: 45%;
 }
 
 .IDCardBottom {
-    height: 40%;
+    height: 55%;
 }
 
 .IDCardIcon {
@@ -131,8 +131,12 @@
     font-size: 15px;
 }
 
+.geoLocationBlock {
+    height: Calc(100% - 60%);
+}
+
 .digitalMediaBlock {
-    height: Calc(100% - 70px);
+    height: Calc(100% - 40% - 70px);
 }
 
 .digitalMediaSlider {

--- a/src/components/search/search.module.scss
+++ b/src/components/search/search.module.scss
@@ -1,13 +1,28 @@
 /* Custom styling for the Search Page */
 
-.content {
-    height: Calc(100vh - 200px);
+.searchContent {
+    height: calc(100vh - 208px)
+}
+
+.searchPageBlock {
+    transition: 0.4s;
 }
 
 /* Search Menu */
 .searchMenu {
-    left: 0;
-    background-color: var(--main-color-light);
+    border: 1px solid var(--grey);
+}
+
+.searchBlock {
+    background-color: var((--primary));
+}
+
+.searchBar {
+    border-radius: 8px;
+}
+
+.searchBar::placeholder {
+    font-style: italic;
 }
 
 /* Filter Menu */
@@ -41,4 +56,109 @@
 
 .filterAggregation {
     font-size: 13px;
+}
+
+/* Search Results */
+.searchResults {
+    height: Calc(100% - 40px);
+}
+
+.table {
+    border: 1px solid var(--secondary);
+    border-radius: 8px;
+}
+
+.paginator {
+    height: 40px;
+}
+
+.returnButton {
+    background-color: var(--primary);
+    color: white;
+    border: none;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+    height: 30px;
+    margin-top: -25px;
+}
+
+/* ID Card */
+.IDCard {
+    height: Calc(100% - 40px);
+}
+
+.IDCardTop {
+    height: 60%;
+}
+
+.IDCardBottom {
+    height: 40%;
+}
+
+.IDCardIcon {
+    font-size: 25px;
+    color: var(--primary);
+}
+
+.IDCardTitle {
+    font-size: 22px;
+}
+
+.IDCardId {
+    font-size: 14px;
+    color: var(--greyDark);
+}
+
+.midsBar {
+    background-color: #d4f3f7;
+    height: 15px;
+    border-radius: 999px;
+}
+
+.midsProgressionLevel {
+    background-color: var(--accent);
+    width: 15%;
+    transition: 1s;
+    border-radius: 999px;
+}
+
+.midsTitle {
+    font-size: 18px;
+    color: var(--accent);
+}
+
+.IDCardProperty {
+    font-size: 15px;
+}
+
+.digitalMediaBlock {
+    height: Calc(100% - 70px);
+}
+
+.digitalMediaSlider {
+    overflow-x: scroll;
+    overflow-y: hidden;
+    white-space: nowrap;
+}
+
+.digitalMediaItem {
+    border-radius: 8px;
+}
+
+.buttonBlock {
+    height: 60px;
+}
+
+.specimenButton {
+    height: 35px;
+    border: none;
+    background-color: var(--primary);
+    color: white;
+    font-size: 14px;
+    border-radius: 999px;
+    transition: 0.4s;
+}
+
+.specimenButton:hover {
+    background-color: var(--accent);
 }

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -118,7 +118,7 @@ const Specimen = () => {
                                     <IDCard ToggleModal={(property: string) => ToggleModal(property)} />
                                 </Col>
                                 <Col md={{ span: 9 }} className="ps-5 h-100">
-                                    <ContentBlock ToggleModal={(property: string) => ToggleModal(property)} />
+                                    <ContentBlock ToggleModal={(property: string) => ToggleModal(property)}/>
                                 </Col>
 
                                 {(Object.keys(annotateTarget.target).length > 0 && KeycloakService.IsLoggedIn()) &&

--- a/src/components/specimen/components/IDCard/IDCard.tsx
+++ b/src/components/specimen/components/IDCard/IDCard.tsx
@@ -119,7 +119,7 @@ const IDCard = (props: Props) => {
                                                             onClick={() => ToggleModal('ods:physicalSpecimenId')}
                                                         >
                                                             <p className={`${styles.IDCardProperty} text-primary m-0`}> Physical Specimen ID ({specimen.physicalSpecimenIdType}): </p>
-                                                            <p role="modalTriggerProperty" className={`${styles.IDCardValue} m-0`}> {specimen.physicalSpecimenId} </p>
+                                                            <p className={`${styles.IDCardValue} m-0`}> {specimen.physicalSpecimenId} </p>
                                                         </Col>
                                                     </Row>
                                                     <Row className="mt-1">

--- a/src/components/specimen/components/contentBlock/SpecimenOverview.tsx
+++ b/src/components/specimen/components/contentBlock/SpecimenOverview.tsx
@@ -59,8 +59,8 @@ const SpecimenOverview = (props: Props) => {
                                                 <Row>
                                                     <Col>
                                                         <table className={styles.propertyTable}>
-                                                            <tr>
-                                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                            <tbody>
+                                                                <tr className={`${styles.propertyTableRow} w-100 px-2 d-block`}
                                                                     onClick={() => ToggleModal('dwc:continent')}
                                                                 >
                                                                     <td className={`${styles.propertyTitle} pe-2`}> Continent: </td>
@@ -70,10 +70,8 @@ const SpecimenOverview = (props: Props) => {
                                                                             : 'Not provided'
                                                                         }
                                                                     </td>
-                                                                </div>
-                                                            </tr>
-                                                            <tr onClick={() => ToggleModal('dwc:country')}>
-                                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                                </tr>
+                                                                <tr className={`${styles.propertyTableRow} w-100 px-2 d-block`}
                                                                     onClick={() => ToggleModal('dwc:country')}
                                                                 >
                                                                     <td className={`${styles.propertyTitle} pe-2`}> Country: </td>
@@ -83,10 +81,8 @@ const SpecimenOverview = (props: Props) => {
                                                                             : 'Not provided'
                                                                         }
                                                                     </td>
-                                                                </div>
-                                                            </tr>
-                                                            <tr onClick={() => ToggleModal('dwc:locality')}>
-                                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                                </tr>
+                                                                <tr className={`${styles.propertyTableRow} w-100 px-2 d-block`}
                                                                     onClick={() => ToggleModal('dwc:locality')}
                                                                 >
                                                                     <td className={`${styles.propertyTitle} pe-2`}> Locality: </td>
@@ -96,8 +92,8 @@ const SpecimenOverview = (props: Props) => {
                                                                             : 'Not provided'
                                                                         }
                                                                     </td>
-                                                                </div>
-                                                            </tr>
+                                                                </tr>
+                                                            </tbody>
                                                         </table>
                                                     </Col>
                                                 </Row>
@@ -149,28 +145,28 @@ const SpecimenOverview = (props: Props) => {
                                 <Row className="mt-3">
                                     <Col>
                                         <table className={styles.propertyTable}>
-                                            <tr>
-                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                            <tbody>
+                                                <tr className={`${styles.propertyTableRow} w-100 px-2 d-block`}
                                                     onClick={() => ToggleModal('ods:organisationId')}
                                                 >
                                                     <td className={`${styles.propertyTitle} pe-2`}> ROR: </td>
                                                     <td> {specimen.organisationId} </td>
-                                                </div>
-                                            </tr>
-                                            <tr>
-                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                </tr>
+                                                <tr className={`${styles.propertyTableRow} w-100 px-2 d-block`}
                                                     onClick={() => ToggleModal('ods:organisationName')}
                                                 >
                                                     <td className={`${styles.propertyTitle} pe-2`}> Name: </td>
                                                     <td> {specimen.data['ods:organisationName']} </td>
-                                                </div>
-                                            </tr>
+                                                </tr>
+                                            </tbody>
                                         </table>
 
                                         <div className="position-absolute d-flex justify-content-end bottom-0 z-0">
-                                            <img src={logo(specimen.data['ods:organisationId'].replace('https://ror.org/', ''))}
-                                                className={styles.organisationLogo}
-                                            />
+                                            {specimen.data['ods:organisationId'] &&
+                                                <img src={logo(specimen.data['ods:organisationId'].replace('https://ror.org/', ''))}
+                                                    className={styles.organisationLogo}
+                                                />
+                                            }
                                         </div>
                                     </Col>
                                 </Row>
@@ -189,8 +185,8 @@ const SpecimenOverview = (props: Props) => {
                                 <Row className="mt-3">
                                     <Col>
                                         <table className={styles.propertyTable}>
-                                            <tr>
-                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                            <tbody>
+                                                <tr className={`${styles.propertyTableRow} w-100 px-2 d-block`}
                                                     onClick={() => ToggleModal('ods:collectingNumber')}
                                                 >
                                                     <td className={`${styles.propertyTitle} pe-2`}> Collecting Number: </td>
@@ -200,12 +196,11 @@ const SpecimenOverview = (props: Props) => {
                                                             : 'Not provided'
                                                         }
                                                     </td>
-                                                </div>
-                                            </tr>
-                                            <tr>
-                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+                                                </tr>
+                                                <tr className={`${styles.propertyTableRow} w-100 px-2 d-block`}
                                                     onClick={() => ToggleModal('ods:collector')}
                                                 >
+
                                                     <td className={`${styles.propertyTitle} pe-2`}> Collector: </td>
                                                     <td>
                                                         {specimen.data['ods:collector'] ?
@@ -213,10 +208,9 @@ const SpecimenOverview = (props: Props) => {
                                                             : 'Not provided'
                                                         }
                                                     </td>
-                                                </div>
-                                            </tr>
-                                            <tr>
-                                                <div className={`${styles.propertyTableRow} w-100 px-2`}
+
+                                                </tr>
+                                                <tr className={`${styles.propertyTableRow} w-100 px-2 d-block`}
                                                     onClick={() => ToggleModal('ods:dateCollected')}
                                                 >
                                                     <td className={`${styles.propertyTitle} pe-2`}> Date Collected: </td>
@@ -226,8 +220,8 @@ const SpecimenOverview = (props: Props) => {
                                                             : 'Not provided'
                                                         }
                                                     </td>
-                                                </div>
-                                            </tr>
+                                                </tr>
+                                            </tbody>
                                         </table>
                                     </Col>
                                 </Row>
@@ -235,8 +229,8 @@ const SpecimenOverview = (props: Props) => {
                         </Card>
                     </Col>
                 </Row>
-            </Col>
-        </Row>
+            </Col >
+        </Row >
     );
 }
 

--- a/src/redux/search/SearchSlice.ts
+++ b/src/redux/search/SearchSlice.ts
@@ -3,7 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { RootState } from 'app/store';
 
 /* Import Types */
-import { Specimen } from 'global/Types';
+import { Specimen, Dict } from 'global/Types';
 
 
 export interface SearchState {
@@ -15,6 +15,7 @@ export interface SearchState {
         organisationId?: string
     };
     searchResults: Specimen[];
+    searchAggregations: Dict;
     searchSpecimen: Specimen;
 }
 
@@ -26,6 +27,7 @@ const initialState: SearchState = {
         idValue: ''
     },
     searchResults: <Specimen[]>[],
+    searchAggregations: {} as Dict,
     searchSpecimen: {} as Specimen
 };
 
@@ -42,8 +44,11 @@ export const SearchSlice = createSlice({
         setSearchPhysicalId: (state, action: PayloadAction<SearchState['searchPhysicalId']>) => {
             state.searchPhysicalId = action.payload;
         },
-        setSpecimenSearchResults: (state, action: PayloadAction<Specimen[]>) => {
+        setSearchResults: (state, action: PayloadAction<Specimen[]>) => {
             state.searchResults = action.payload;
+        },
+        setSearchAggregations: (state, action: PayloadAction<Dict>) => {
+            state.searchAggregations = action.payload;
         },
         setSearchSpecimen: (state, action: PayloadAction<Specimen>) => {
             state.searchSpecimen = action.payload;
@@ -56,7 +61,8 @@ export const {
     setSearchQuery,
     setSearchPIDQuery,
     setSearchPhysicalId,
-    setSpecimenSearchResults,
+    setSearchResults,
+    setSearchAggregations,
     setSearchSpecimen
 } = SearchSlice.actions;
 
@@ -64,7 +70,8 @@ export const {
 export const getSearchQuery = (state: RootState) => state.search.searchQuery;
 export const getSearchPIDQuery = (state: RootState) => state.search.searchPIDQuery;
 export const getSearchPhysicalId = (state: RootState) => state.search.searchPhysicalId;
-export const getSpecimenSearchResults = (state: RootState) => state.search.searchResults;
+export const getSearchResults = (state: RootState) => state.search.searchResults;
+export const getSearchAggregations = (state: RootState) => state.search.searchAggregations;
 export const getSearchSpecimen = (state: RootState) => state.search.searchSpecimen;
 
 export default SearchSlice.reducer;

--- a/src/redux/search/SearchSlice.ts
+++ b/src/redux/search/SearchSlice.ts
@@ -14,7 +14,8 @@ export interface SearchState {
         idValue: string,
         organisationId?: string
     };
-    specimenSearchResults: Specimen[];
+    searchResults: Specimen[];
+    searchSpecimen: Specimen;
 }
 
 const initialState: SearchState = {
@@ -24,7 +25,8 @@ const initialState: SearchState = {
         idType: 'gui',
         idValue: ''
     },
-    specimenSearchResults: <Specimen[]>[]
+    searchResults: <Specimen[]>[],
+    searchSpecimen: {} as Specimen
 };
 
 export const SearchSlice = createSlice({
@@ -41,7 +43,10 @@ export const SearchSlice = createSlice({
             state.searchPhysicalId = action.payload;
         },
         setSpecimenSearchResults: (state, action: PayloadAction<Specimen[]>) => {
-            state.specimenSearchResults = action.payload;
+            state.searchResults = action.payload;
+        },
+        setSearchSpecimen: (state, action: PayloadAction<Specimen>) => {
+            state.searchSpecimen = action.payload;
         }
     },
 })
@@ -51,13 +56,15 @@ export const {
     setSearchQuery,
     setSearchPIDQuery,
     setSearchPhysicalId,
-    setSpecimenSearchResults
+    setSpecimenSearchResults,
+    setSearchSpecimen
 } = SearchSlice.actions;
 
 /* Connect with Root State */
 export const getSearchQuery = (state: RootState) => state.search.searchQuery;
 export const getSearchPIDQuery = (state: RootState) => state.search.searchPIDQuery;
 export const getSearchPhysicalId = (state: RootState) => state.search.searchPhysicalId;
-export const getSpecimenSearchResults = (state: RootState) => state.search.specimenSearchResults;
+export const getSpecimenSearchResults = (state: RootState) => state.search.searchResults;
+export const getSearchSpecimen = (state: RootState) => state.search.searchSpecimen;
 
 export default SearchSlice.reducer;


### PR DESCRIPTION
PR expands the ID Card feature to the Search Page. It is however, not the same as the current one on the Specimen Page, but based on the same principle. The current search flow: the user can search for specimens by filters, results will show up, the user can select a specimen from the table, the table shrinks and covers the filters, revealing the ID Card containing the primary Specimen details and digital media if so. A button called: 'See more details' leads the user to the full Specimen page. The filters can be shown again by pressing the return button.

Adds:
- ID Card containing primary Specimen information on the Search Page
- Styling based upon designs to results table and ID card on the Search Page
- Functionality to switch between filters and the ID Card by shrinking the columns in size and or positioning them differently with the help of position absolute