### PR TITLE
Re-enable Versioning / Add Error Message

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import Specimen from "components/specimen/Specimen";
 import DigitalMedia from "components/digitalMedia/DigitalMedia";
 import Annotate from "components/annotate/Annotate";
 import Profile from "components/profile/Profile";
+import ErrorMessage from "components/general/errorMessage/ErrorMessage";
 
 /* Import API */
 import GetUser from "api/user/GetUser";
@@ -77,6 +78,8 @@ const App = () => {
         <Route path="/profile" element={<Profile />} />
         <Route path="/profile/:userId" element={<Profile />} />
       </Routes>
+
+      <ErrorMessage />
     </Router>
   );
 }

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -3,6 +3,7 @@ import { combineReducers, configureStore, ThunkAction, Action } from '@reduxjs/t
 import type { PreloadedState } from '@reduxjs/toolkit';
 
 /* Import Redux Slices */
+import GeneralReducer from 'redux/general/GeneralSlice';
 import SearchReducer from 'redux/search/SearchSlice';
 import SpecimenReducer from 'redux/specimen/SpecimenSlice';
 import DigitalMediaReducer from 'redux/digitalMedia/DigitalMediaSlice';
@@ -11,6 +12,7 @@ import UserReducer from 'redux/user/UserSlice';
 
 
 const rootReducer = combineReducers({
+  general: GeneralReducer,
   search: SearchReducer,
   specimen: SpecimenReducer,
   digitalMedia: DigitalMediaReducer,

--- a/src/components/general/errorMessage/ErrorMessage.tsx
+++ b/src/components/general/errorMessage/ErrorMessage.tsx
@@ -1,0 +1,51 @@
+/* Import Dependencies */
+import { useEffect, useState } from 'react';
+import classNames from 'classnames';
+
+/* Import Store */
+import { useAppSelector, useAppDispatch } from 'app/hooks';
+import { getErrorMessage, setErrorMessage } from 'redux/general/GeneralSlice';
+
+/* Import Styles */
+import styles from './errorMessage.module.scss';
+
+
+const ErrorMessage = () => {
+    /* Hooks */
+    const dispatch = useAppDispatch();
+
+    /* Base variables */
+    const errorMessage = useAppSelector(getErrorMessage);
+    const [active, setActive] = useState(false);
+
+    /* OnChange of Error Message */
+    useEffect(() => {
+        /* Check if Error Message is not empty */
+        if (errorMessage) {
+            setActive(true);
+
+            setTimeout(() => {
+                setActive(false);
+
+                /* Reset Error Message */
+                dispatch(setErrorMessage(''));
+            }, 4500);
+        }
+    }, [errorMessage]);
+
+    /* ClassName for Error Message */
+    const classErrorMessage = classNames({
+        [`${styles.errorMessage}`]: true,
+        [`${styles.active}`]: active
+    });
+
+    return (
+        <div className={`${classErrorMessage} px-3 py-2 position-absolute top-0 mt-5 start-0 end-0`}>
+            <p className={`${styles.errorMessageTitle} fw-bold`}> Something went Wrong! </p>
+
+            <p className={styles.errorMessageContent}> {errorMessage} </p> 
+        </div>
+    );
+}
+
+export default ErrorMessage;

--- a/src/components/general/errorMessage/errorMessage.module.scss
+++ b/src/components/general/errorMessage/errorMessage.module.scss
@@ -1,0 +1,20 @@
+.errorMessage {
+    opacity: 0;
+    width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: rgb(231, 76, 60, 0.8);
+    transition: 0.4s;
+}
+
+.errorMessage.active {
+    opacity: 1;
+}
+
+.errorMessageTitle {
+    font-size: 16px;
+}
+
+.errorMessageContent {
+    font-size: 15px;
+}

--- a/src/components/specimen/components/contentBlock/VersionSelect.tsx
+++ b/src/components/specimen/components/contentBlock/VersionSelect.tsx
@@ -5,7 +5,7 @@ import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
-import { getSpecimen, setSpecimenVersion } from 'redux/specimen/SpecimenSlice';
+import { getSpecimen, getSpecimenVersion, setSpecimenVersion } from 'redux/specimen/SpecimenSlice';
 
 /* Import API */
 import GetSpecimenVersions from 'api/specimen/GetSpecimenVersions';
@@ -16,7 +16,8 @@ const VersionSelect = () => {
     const dispatch = useAppDispatch();
 
     /* Base variables */
-    const specimen = useAppSelector(getSpecimen);
+    const specimen = useAppSelector(getSpecimen)
+    const version = useAppSelector(getSpecimenVersion);
     const [versions, setVersions] = useState<number[]>([]);
 
     /* OnLoad: Fetch Specimen versions */
@@ -44,7 +45,7 @@ const VersionSelect = () => {
         <Row>
             <Col>
                 <Select 
-                    defaultValue={{ value: specimen.version, label: `Version ${specimen.version}` }}
+                    value={{ value: version, label: `Version ${version}` }}
                     options={selectOptions}
                     styles={{ menu: provided => ({ ...provided, zIndex: 100000 }) }}
                     onChange={(option) => { option?.value && dispatch(setSpecimenVersion(option.value)) }}

--- a/src/redux/general/GeneralSlice.ts
+++ b/src/redux/general/GeneralSlice.ts
@@ -1,0 +1,32 @@
+/* Import Dependencies */
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { RootState } from 'app/store';
+
+
+export interface GeneralState {
+    errorMessage: string;
+}
+
+const initialState: GeneralState = {
+    errorMessage: ''
+};
+
+export const GeneralSlice = createSlice({
+    name: 'general',
+    initialState,
+    reducers: {
+        setErrorMessage: (state, action: PayloadAction<string>) => {
+            state.errorMessage = action.payload;
+        }
+    },
+})
+
+/* Action Creators */
+export const {
+    setErrorMessage
+} = GeneralSlice.actions;
+
+/* Connect with Root State */
+export const getErrorMessage = (state: RootState) => state.general.errorMessage;
+
+export default GeneralSlice.reducer;


### PR DESCRIPTION
Commit re-enables versioning for Specimens with version that do work. Specimens that still got the old method of handling versions in the back-end give an Error Message. An Error Message template was added to display the error.

Adds:
- Error Message template

Modifies:
- Re-enables versions
- Selecting a version of a Specimen now only refreshes the Specimen data (not Digital Media or Annotations) with the new version